### PR TITLE
Do not output empty geometries

### DIFF
--- a/pluto_build/sql/export_mappluto_gdb.sql
+++ b/pluto_build/sql/export_mappluto_gdb.sql
@@ -96,7 +96,7 @@ SELECT
 	st_makevalid(b.:GEOM) as geom
 INTO :TABLE
 FROM export_pluto a, pluto_geom b
-WHERE b.:GEOM IS NOT NULL
+WHERE b.:GEOM IS NOT NULL AND NOT ST_IsEmpty(b.:GEOM)
 AND a.bbl::bigint = b.bbl::bigint;
 
 ALTER TABLE :TABLE ALTER COLUMN "Borough" SET NOT NULL;

--- a/pluto_build/sql/export_mappluto_shp.sql
+++ b/pluto_build/sql/export_mappluto_shp.sql
@@ -95,7 +95,7 @@ SELECT
 	st_makevalid(b.:GEOM) as geom
 INTO :TABLE
 FROM export_pluto a, pluto_geom b
-WHERE b.:GEOM IS NOT NULL
+WHERE b.:GEOM IS NOT NULL AND NOT ST_IsEmpty(b.:GEOM)
 AND a.bbl::bigint = b.bbl::bigint;
 
 ALTER TABLE :TABLE ALTER COLUMN "Borough" SET NOT NULL;


### PR DESCRIPTION
Current method of exporting clipped file looks for geometries that are NULL. The method used to clip, however, creates 'MULTIPOLYGON EMPTY' rather than a NULL value.