### PR TITLE
Make valid geoms prior to union on bbl

### DIFF
--- a/pluto_build/sql/dtmmergepolygons.sql
+++ b/pluto_build/sql/dtmmergepolygons.sql
@@ -22,7 +22,7 @@ GROUP BY primebbl);
 -- create merged geometries for non-condo records
 DROP TABLE IF EXISTS pluto_dtm_noncondosmerged;
 CREATE TABLE pluto_dtm_noncondosmerged AS (
-SELECT bbl, ST_Union(geom) geom
+SELECT bbl, ST_Union(ST_MakeValid(geom)) geom
 FROM pluto_dtm
 WHERE bbl IS NOT NULL
 AND primebbl IS NULL


### PR DESCRIPTION
Previously, GIS pre-corrected geometries so we wouldn't get `IllegalArgumentException: Invalid number of points in LinearRing found 3 - must be 0 or >= 4`.  In the most recent DTM, this occurs for BBL 3044520170. ST_MakeValid corrects this BBL when starting with the "raw" dof_dtm.

Running ST_MakeValid on '4017480018', '4017480019', '4017480080', '4017480082' does not appear to introduce slivers.

We should investigate if we can then remove subsequent validations: https://github.com/NYCPlanning/db-pluto/blob/1c1d153418f2194ef2f145b651602e15ca3277eb/pluto_build/sql/plutogeoms.sql#L7

https://github.com/NYCPlanning/db-pluto/blob/1c1d153418f2194ef2f145b651602e15ca3277eb/pluto_build/sql/dtmgeoms.sql#L33