### PR TITLE
Switch dataloading from fastloading.py to import from data library

### DIFF
--- a/pluto_build/01_dataloading.sh
+++ b/pluto_build/01_dataloading.sh
@@ -19,6 +19,7 @@ import pluto_input_numbldgs &
 import pluto_input_geocodes &
 
 # Import spatial bounaries from data library
+import dcp_edesignation &
 import dcp_cdboundaries &
 import dcp_censustracts &
 import dcp_censusblocks &

--- a/pluto_build/01_dataloading.sh
+++ b/pluto_build/01_dataloading.sh
@@ -23,7 +23,7 @@ import dcp_edesignation &
 import dcp_cdboundaries &
 import dcp_censustracts &
 import dcp_censusblocks &
-import dcp_schooldistricts &
+import dcp_school_districts &
 import dcp_firecompanies &
 import dcp_policeprecincts &
 import dcp_councildistricts &

--- a/pluto_build/01_dataloading.sh
+++ b/pluto_build/01_dataloading.sh
@@ -41,6 +41,7 @@ import dcp_zoningmapamendments &
 import dcp_zoningmapindex &
 
 # Import other
+import dcp_plutocorrections &
 import dpr_greenthumb &
 import dsny_frequencies &
 import lpc_historic_districts &

--- a/pluto_build/01_dataloading.sh
+++ b/pluto_build/01_dataloading.sh
@@ -26,6 +26,7 @@ import dcp_censusblocks &
 import dcp_schooldistricts &
 import dcp_firecompanies &
 import dcp_policeprecincts &
+import dcp_councildistricts &
 import dcp_healthareas &
 import dcp_healthcenters &
 import dof_shoreline &
@@ -40,6 +41,10 @@ import dcp_zoningmapamendments &
 import dcp_zoningmapindex &
 
 # Import other
+import dpr_greenthumb &
+import dsny_frequencies &
+import lpc_historic_districts &
+import lpc_landmarks &
 import dcp_colp &
 import dof_dtm &
 import dof_condo

--- a/pluto_build/01_dataloading.sh
+++ b/pluto_build/01_dataloading.sh
@@ -41,7 +41,7 @@ import dcp_zoningmapamendments &
 import dcp_zoningmapindex &
 
 # Import other
-import dcp_plutocorrections &
+import pluto_corrections &
 import dpr_greenthumb &
 import dsny_frequencies &
 import lpc_historic_districts &

--- a/pluto_build/01_dataloading.sh
+++ b/pluto_build/01_dataloading.sh
@@ -12,10 +12,37 @@ BEGIN
 END \$\$;
 "
 
+# Import PTS and CAMA from data library
 import pluto_pts &
 import pluto_input_cama_dof &
 import pluto_input_numbldgs &
 import pluto_input_geocodes &
+
+# Import spatial bounaries from data library
+import dcp_cdboundaries &
+import dcp_censustracts &
+import dcp_censusblocks &
+import dcp_schooldistricts &
+import dcp_firecompanies &
+import dcp_policeprecincts &
+import dcp_healthareas &
+import dcp_healthcenters &
+import dof_shoreline &
+
+# Import zoning files from data library
+import dcp_commercialoverlay &
+import dcp_limitedheight &
+import dcp_zoningdistricts &
+import dcp_specialpurpose &
+import dcp_specialpurposesubdistricts &
+import dcp_zoningmapamendments &
+import dcp_zoningmapindex &
+
+# Import other
+import dcp_colp &
+import dof_dtm &
+import dof_condo
+
 wait
 
 ## load data into the pluto db

--- a/pluto_build/python/fastloading.py
+++ b/pluto_build/python/fastloading.py
@@ -12,7 +12,6 @@ def ETL(table):
 
 if __name__ == "__main__":
     tables = [
-        "pluto_corrections",
         # for spatial joins
         "doitt_zipcodeboundaries",
         # FEMA 2007 and preliminary 2015 100 year flood zones

--- a/pluto_build/python/fastloading.py
+++ b/pluto_build/python/fastloading.py
@@ -14,41 +14,14 @@ if __name__ == "__main__":
     tables = [
         "pluto_corrections",
         "dcp_edesignation",
-        "dcp_colp",
         "lpc_historic_districts",
         "lpc_landmarks",
 
         # for spatial joins
-        "dcp_cdboundaries",
-        "dcp_censustracts",
-        "dcp_censusblocks",
-        "dcp_school_districts",
-        "dcp_councildistricts",
         "doitt_zipcodeboundaries",
-        "dcp_firecompanies",
-        "dcp_policeprecincts",
-        "dcp_healthareas",
-        "dcp_healthcenters",
         "dsny_frequencies",
         "dpr_greenthumb",
-        
-        # raw Digital Tax Map from DOF
-        "dof_dtm",
-        
-        # raw NYC shoreline file from DOF
-        "dof_shoreline",
-        
-        # raw DOF condo table
-        "dof_condo",
-        
-        # DCP zoning datasets~
-        "dcp_commercialoverlay",
-        "dcp_limitedheight",
-        "dcp_zoningdistricts",
-        "dcp_specialpurpose",
-        "dcp_specialpurposesubdistricts",
-        "dcp_zoningmapamendments",
-        "dcp_zoningmapindex",
+        "dcp_councildistricts",
         
         # FEMA 2007 and preliminary 2015 100 year flood zones
         "fema_firms2007_100yr",

--- a/pluto_build/python/fastloading.py
+++ b/pluto_build/python/fastloading.py
@@ -13,12 +13,8 @@ def ETL(table):
 if __name__ == "__main__":
     tables = [
         "pluto_corrections",
-        "lpc_landmarks",
-
         # for spatial joins
         "doitt_zipcodeboundaries",
-        "dsny_frequencies",
-        
         # FEMA 2007 and preliminary 2015 100 year flood zones
         "fema_firms2007_100yr",
         "fema_pfirms2015_100yr"

--- a/pluto_build/python/fastloading.py
+++ b/pluto_build/python/fastloading.py
@@ -13,7 +13,6 @@ def ETL(table):
 if __name__ == "__main__":
     tables = [
         "pluto_corrections",
-        "dcp_edesignation",
         "lpc_historic_districts",
         "lpc_landmarks",
 

--- a/pluto_build/python/fastloading.py
+++ b/pluto_build/python/fastloading.py
@@ -13,14 +13,11 @@ def ETL(table):
 if __name__ == "__main__":
     tables = [
         "pluto_corrections",
-        "lpc_historic_districts",
         "lpc_landmarks",
 
         # for spatial joins
         "doitt_zipcodeboundaries",
         "dsny_frequencies",
-        "dpr_greenthumb",
-        "dcp_councildistricts",
         
         # FEMA 2007 and preliminary 2015 100 year flood zones
         "fema_firms2007_100yr",


### PR DESCRIPTION
#234 

The name of dcp_school_districts got changed to dcp_schooldistricts when we switched over to data-library.

Depends on https://github.com/NYCPlanning/db-data-library/pull/137 