### PR TITLE
Historical schema

### DIFF
--- a/schemas/dcp_mappluto_02b.json
+++ b/schemas/dcp_mappluto_02b.json
@@ -172,7 +172,7 @@
     {
         "description": "The number of buildings on the tax lot.",
         "name": "numbldgs",
-        "type": "INTEGER"
+        "type": "FLOAT"
     },
     {
         "description": "In the tallest building on the tax lot, the number of full and partial stories starting from the ground floor.",

--- a/schemas/dcp_mappluto_02b.json
+++ b/schemas/dcp_mappluto_02b.json
@@ -182,12 +182,12 @@
     {
         "description": "The sum of residential units in all buildings on the tax lot.",
         "name": "unitsres",
-        "type": "INTEGER"
+        "type": "FLOAT"
     },
     {
         "description": "The sum of residential and non-residential (offices, retail sotres, etc.) units in all buildings on the tax lot.",
         "name": "unitstotal",
-        "type": "INTEGER"
+        "type": "FLOAT"
     },
     {
         "description": "The tax lot's frontage measured in feet.",
@@ -282,7 +282,7 @@
     {
         "description": "The borough the tax lot is located in.",
         "name": "borocode",
-        "type": "INTEGER"
+        "type": "FLOAT"
     },
     {
         "description": "",


### PR DESCRIPTION
Note that we will do two step load
1. load to data library so that we have a csv version to read schema with
2. generate schema.json for that version of pluto and upload to this branch
3. trigger a second workflow dispatch to load that version (without loading to data library)

To bulk generate historical PLUTO schema:
```python
import pandas as pd
import json
import requests

def schema():
  return requests.get('https://raw.githubusercontent.com/NYCPlanning/db-pluto/main/schemas/dcp_mappluto.json').json()

def comput_schema(version):
  df = pd.read_csv(f'https://nyc3.digitaloceanspaces.com/edm-recipes/datasets/dcp_mappluto/{version}/dcp_mappluto.csv', nrows=2)
  current_schema = schema()
  new_schema = []
  for col in df.columns:
    col = col.lower()
    if col in [s['name'] for s in current_schema]:
      new_schema.append(
          [s for s in schema if s['name'] == col][0]
      )
    else:
      new_schema.append(
        {
          "name": col,
          "type": "STRING",
          "description": ""
        }
      )
  with open(f'dcp_mappluto_{version}.json', 'w') as f: 
    json.dump(new_schema, f, indent=4, sort_keys=True)
  return new_schema
```