### PR TITLE
Count null and non-null as mismatch in QAQC

### DIFF
--- a/pluto_build/sql/qaqc_mismatch.sql
+++ b/pluto_build/sql/qaqc_mismatch.sql
@@ -1,20 +1,9 @@
-DELETE FROM qaqc_mismatch 
+DELETE FROM dcp_pluto.qaqc_mismatch 
 WHERE pair = :'VERSION'||' - '||:'VERSION_PREV' 
 AND CONDO::boolean = :CONDO
 AND MAPPED::boolean = :MAPPED;
-DROP TABLE IF EXISTS qaqc_mismatch;
-CREATE TABLE qaqc_mismatch (
-    -- pair varchar,
-    -- condo varchar,
-    -- mapped varchar,
-    total numeric,
-    borough numeric,
-    block numeric,
-    lot numeric
-    -- cd numeric 
-);
 
--- INSERT INTO qaqc_mismatch (
+INSERT INTO qaqc_mismatch (
 SELECT
     :'VERSION'||' - '||:'VERSION_PREV' as pair, 
 	:CONDO as condo,

--- a/pluto_build/sql/qaqc_mismatch.sql
+++ b/pluto_build/sql/qaqc_mismatch.sql
@@ -1,45 +1,56 @@
-DELETE FROM dcp_pluto.qaqc_mismatch 
-WHERE pair = :'VERSION'||' - '||:'VERSION_PREV' 
-AND CONDO::boolean = :CONDO
-AND MAPPED::boolean = :MAPPED;
+-- DELETE FROM qaqc_mismatch 
+-- WHERE pair = :'VERSION'||' - '||:'VERSION_PREV' 
+-- AND CONDO::boolean = :CONDO
+-- AND MAPPED::boolean = :MAPPED;
+DROP TABLE IF EXISTS qaqc_mismatch;
+-- CREATE TABLE qaqc_mismatch (
+--     -- pair varchar,
+--     -- condo varchar,
+--     -- mapped varchar,
+--     total numeric,
+--     borough numeric,
+--     block numeric,
+--     lot numeric
+--     -- cd numeric 
+-- );
 
-INSERT INTO dcp_pluto.qaqc_mismatch (
+-- INSERT INTO qaqc_mismatch (
 SELECT
-    :'VERSION'||' - '||:'VERSION_PREV' as pair, 
-	:CONDO as condo,
-    :MAPPED as mapped,
+    -- :'VERSION'||' - '||:'VERSION_PREV' as pair, 
+	-- :CONDO as condo,
+    -- :MAPPED as mapped,
     count(*) as total,
-    count(nullif(a.borough = b.borough, true)) as borough,
-    count(nullif(a.block::numeric = b.block::numeric, true)) as block,
-    count(nullif(a.lot::numeric = b.lot::numeric, true)) as lot,
-    count(nullif(a.cd::numeric = b.cd::numeric, true)) as cd,
-    count(nullif(a.ct2010 = b.ct2010, true)) as ct2010,
-    count(nullif(a.cb2010 = b.cb2010, true)) as cb2010,
-    count(nullif(a.schooldist = b.schooldist, true)) as schooldist,
-    count(nullif(a.council::numeric = b.council::numeric, true)) as council,
-    count(nullif(a.zipcode::numeric = b.zipcode::numeric, true)) as zipcode,
-    count(nullif(a.firecomp = b.firecomp, true)) as firecomp,
-    count(nullif(a.policeprct::numeric = b.policeprct::numeric, true)) as policeprct,
-    count(nullif(a.healtharea::numeric = b.healtharea::numeric, true)) as healtharea,
-    count(nullif(a.sanitboro = b.sanitboro, true)) as sanitboro,
-    count(nullif(a.sanitsub = b.sanitsub, true)) as sanitsub,
-    count(nullif(trim(a.address) = trim(b.address), true)) as address,
-    count(nullif(a.zonedist1 = b.zonedist1, true)) as zonedist1,
-    count(nullif(a.zonedist2 = b.zonedist2, true)) as zonedist2,
-    count(nullif(a.zonedist3 = b.zonedist3, true)) as zonedist3,
-    count(nullif(a.zonedist4 = b.zonedist4, true)) as zonedist4,
-    count(nullif(a.overlay1 = b.overlay1, true)) as overlay1,
-    count(nullif(a.overlay2 = b.overlay2, true)) as overlay2,
-    count(nullif(a.spdist1 = b.spdist1, true)) as spdist1,
-    count(nullif(a.spdist2 = b.spdist2, true)) as spdist2,
-    count(nullif(a.spdist3 = b.spdist3, true)) as spdist3,
-    count(nullif(a.ltdheight = b.ltdheight, true)) as ltdheight,
-    count(nullif(a.splitzone = b.splitzone, true)) as splitzone,
-    count(nullif(a.bldgclass = b.bldgclass, true)) as bldgclass,
-    count(nullif(a.landuse = b.landuse, true)) as landuse,
-    count(nullif(a.easements::numeric = b.easements::numeric, true)) as easements,
-    count(nullif(a.ownertype = b.ownertype, true)) as ownertype,
-    count(nullif(a.ownername = b.ownername, true)) as ownername,
+    count(*) FILTER (WHERE a.borough IS DISTINCT FROM b.borough) as borough,
+    count(*) FILTER (WHERE a.block::varchar IS DISTINCT FROM b.block::varchar) as block,
+    count(*) FILTER (WHERE a.lot::varchar IS DISTINCT FROM b.lot::varchar) as lot,
+    count(*) FILTER (WHERE a.cd::varchar IS DISTINCT FROM b.cd::varchar) as cd,
+    count(*) FILTER (WHERE a.ct2010::varchar IS DISTINCT FROM b.ct2010::varchar) as ct2010,
+    count(*) FILTER (WHERE a.cb2010 IS DISTINCT FROM b.cb2010) as cb2010,
+    count(*) FILTER (WHERE a.schooldist IS DISTINCT FROM b.schooldist) as schooldist,
+    count(*) FILTER (WHERE a.council::varchar IS DISTINCT FROM b.council::varchar) as council,
+    count(*) FILTER (WHERE a.zipcode::varchar IS DISTINCT FROM b.zipcode::varchar) as zipcode,
+    count(*) FILTER (WHERE a.firecomp::varchar IS DISTINCT FROM b.firecomp::varchar) as firecomp,
+    count(*) FILTER (WHERE a.policeprct::varchar IS DISTINCT FROM b.policeprct::varchar) as policeprct,
+    count(*) FILTER (WHERE a.healtharea::varchar IS DISTINCT FROM b.healtharea::varchar) as healtharea,
+    count(*) FILTER (WHERE a.sanitboro::varchar IS DISTINCT FROM b.sanitboro::varchar) as sanitboro,
+    count(*) FILTER (WHERE a.sanitsub::varchar IS DISTINCT FROM b.sanitsub::varchar) as sanitsub,
+    count(*) FILTER (WHERE trim(a.address) IS DISTINCT FROM trim(b.address)) as address,
+    count(*) FILTER (WHERE a.zonedist1 IS DISTINCT FROM b.zonedist1) as zonedist1,
+    count(*) FILTER (WHERE a.zonedist2 IS DISTINCT FROM b.zonedist2) as zonedist2,
+    count(*) FILTER (WHERE a.zonedist3 IS DISTINCT FROM b.zonedist3) as zonedist3,
+    count(*) FILTER (WHERE a.zonedist4 IS DISTINCT FROM b.zonedist4) as zonedist4,
+    count(*) FILTER (WHERE a.overlay1 IS DISTINCT FROM b.overlay1) as overlay1,
+    count(*) FILTER (WHERE a.overlay2 IS DISTINCT FROM b.overlay2) as overlay2,
+    count(*) FILTER (WHERE a.spdist1 IS DISTINCT FROM b.spdist1) as spdist1,
+    count(*) FILTER (WHERE a.spdist2 IS DISTINCT FROM b.spdist2) as spdist2,
+    count(*) FILTER (WHERE a.spdist3 IS DISTINCT FROM b.spdist3) as spdist3,
+    count(*) FILTER (WHERE a.ltdheight IS DISTINCT FROM b.ltdheight) as ltdheight,
+    count(*) FILTER (WHERE a.splitzone IS DISTINCT FROM b.splitzone) as splitzone,
+    count(*) FILTER (WHERE a.bldgclass IS DISTINCT FROM b.bldgclass) as bldgclass,
+    count(*) FILTER (WHERE a.landuse IS DISTINCT FROM b.landuse) as landuse,
+    count(*) FILTER (WHERE a.easements::numeric IS DISTINCT FROM b.easements::numeric) as easements,
+    count(*) FILTER (WHERE a.ownertype IS DISTINCT FROM b.ownertype) as ownertype,
+    count(*) FILTER (WHERE a.ownername IS DISTINCT FROM b.ownername) as ownername,
     count(nullif(abs(a.lotarea::numeric-b.lotarea::numeric) <5, true)) as lotarea,
     count(nullif(abs(a.bldgarea::numeric-b.bldgarea::numeric) <5, true)) as bldgarea,
     count(nullif(abs(a.comarea::numeric-b.comarea::numeric) <5, true)) as comarea,
@@ -96,7 +107,7 @@ SELECT
     count(nullif(a.healthcenterdistrict::numeric = b.healthcenterdistrict::numeric, true)) as healthcenterdistrict,
     count(nullif(a.firm07_flag = b.firm07_flag, true)) as firm07_flag,
     count(nullif(a.pfirm15_flag = b.pfirm15_flag, true)) as pfirm15_flag
-    FROM dcp_pluto.:"VERSION" a
-INNER JOIN dcp_pluto.:"VERSION_PREV" b
-ON (a.bbl::bigint = b.bbl::bigint)
-:CONDITION)
+    INTO qaqc_mismatch
+    FROM export_pluto a
+INNER JOIN dcp_pluto b
+ON ROUND(a.bbl::float):: bigint = ROUND(b.bbl::float)::bigint;

--- a/pluto_build/sql/qaqc_mismatch.sql
+++ b/pluto_build/sql/qaqc_mismatch.sql
@@ -51,63 +51,97 @@ SELECT
     count(*) FILTER (WHERE a.easements::numeric IS DISTINCT FROM b.easements::numeric) as easements,
     count(*) FILTER (WHERE a.ownertype IS DISTINCT FROM b.ownertype) as ownertype,
     count(*) FILTER (WHERE a.ownername IS DISTINCT FROM b.ownername) as ownername,
-    count(*) FILTER (WHERE abs(a.lotarea::int - b.lotarea::int)>=5 OR 
+    count(*) FILTER (WHERE abs(a.lotarea::numeric - b.lotarea::numeric)>=5 OR 
         ((a.lotarea IS NULL)::int + (b.lotarea IS NULL)::int) = 1) as lotarea,
-    count(nullif(abs(a.bldgarea::numeric-b.bldgarea::numeric) <5, true)) as bldgarea,
-    count(nullif(abs(a.comarea::numeric-b.comarea::numeric) <5, true)) as comarea,
-    count(nullif(abs(a.resarea::numeric-b.resarea::numeric) <5, true)) as resarea,
-    count(nullif(abs(a.officearea::numeric-b.officearea::numeric) <5, true)) as officearea,
-    count(nullif(abs(a.retailarea::numeric-b.retailarea::numeric) <5, true)) as retailarea,
-    count(nullif(abs(a.garagearea::numeric-b.garagearea::numeric) <5, true)) as garagearea,
-    count(nullif(abs(a.strgearea::numeric-b.strgearea::numeric) <5, true)) as strgearea,
-    count(nullif(abs(a.factryarea::numeric-b.factryarea::numeric) <5, true)) as factryarea,
-    count(nullif(abs(a.otherarea::numeric-b.otherarea::numeric) <5, true)) as otherarea,
+    count(*) FILTER (WHERE abs(a.bldgarea::numeric - b.bldgarea::numeric)>=5 OR 
+        ((a.bldgarea IS NULL)::int + (b.bldgarea IS NULL)::int) = 1) as bldgarea,
+    count(*) FILTER (WHERE abs(a.comarea::numeric - b.comarea::numeric)>=5 OR 
+        ((a.comarea IS NULL)::int + (b.comarea IS NULL)::int) = 1) as comarea,
+    count(*) FILTER (WHERE abs(a.resarea::numeric - b.resarea::numeric)>=5 OR 
+        ((a.resarea IS NULL)::int + (b.resarea IS NULL)::int) = 1) as resarea,
+    count(*) FILTER (WHERE abs(a.officearea::numeric - b.officearea::numeric)>=5 OR 
+        ((a.officearea IS NULL)::int + (b.officearea IS NULL)::int) = 1) as officearea,
+    count(*) FILTER (WHERE abs(a.retailarea::numeric - b.retailarea::numeric)>=5 OR 
+        ((a.retailarea IS NULL)::int + (b.retailarea IS NULL)::int) = 1) as retailarea,
+    count(*) FILTER (WHERE abs(a.garagearea::numeric - b.garagearea::numeric)>=5 OR 
+        ((a.garagearea IS NULL)::int + (b.garagearea IS NULL)::int) = 1) as garagearea,
+    count(*) FILTER (WHERE abs(a.strgearea::numeric - b.strgearea::numeric)>=5 OR 
+        ((a.strgearea IS NULL)::int + (b.strgearea IS NULL)::int) = 1) as strgearea,
+    count(*) FILTER (WHERE abs(a.factryarea::numeric - b.factryarea::numeric)>=5 OR 
+        ((a.factryarea IS NULL)::int + (b.factryarea IS NULL)::int) = 1) as factryarea,
+    count(*) FILTER (WHERE abs(a.otherarea::numeric - b.otherarea::numeric)>=5 OR 
+        ((a.otherarea IS NULL)::int + (b.otherarea IS NULL)::int) = 1) as otherarea,
     count(*) FILTER (WHERE a.areasource IS DISTINCT FROM b.areasource) as areasource,
-    count(nullif(a.numbldgs::numeric = b.numbldgs::numeric, true)) as numbldgs,
-    count(nullif(a.numfloors::numeric = b.numfloors::numeric, true)) as numfloors,
-    count(nullif(a.unitsres::numeric = b.unitsres::numeric, true)) as unitsres,
-    count(nullif(a.unitstotal::numeric = b.unitstotal::numeric, true)) as unitstotal,
-    count(nullif(abs(a.lotfront::numeric-b.lotfront::numeric) <5, true)) as lotfront,
-    count(nullif(abs(a.lotdepth::numeric-b.lotdepth::numeric) <5, true)) as lotdepth,
-    count(nullif(abs(a.bldgfront::numeric-b.bldgfront::numeric) <5, true)) as bldgfront,
-    count(nullif(abs(a.bldgdepth::numeric-b.bldgdepth::numeric) <5, true)) as bldgdepth,
-    count(nullif(a.ext = b.ext, true)) as ext,
-    count(nullif(a.proxcode = b.proxcode, true)) as proxcode,
-    count(nullif(a.irrlotcode = b.irrlotcode, true)) as irrlotcode,
-    count(nullif(a.lottype = b.lottype, true)) as lottype,
-    count(nullif(a.bsmtcode = b.bsmtcode, true)) as bsmtcode,
-    count(nullif(abs(a.assessland::numeric-b.assessland::numeric) <10, true)) as assessland,
-    count(nullif(abs(a.assesstot::numeric-b.assesstot::numeric) <10, true)) as assesstot,
-    count(nullif(abs(a.exempttot::numeric-b.exempttot::numeric) <10, true)) as exempttot,
-    count(nullif(a.yearbuilt::numeric = b.yearbuilt::numeric, true)) as yearbuilt,
-    count(nullif(a.yearalter1::numeric = b.yearalter1::numeric, true)) as yearalter1,
-    count(nullif(a.yearalter2::numeric = b.yearalter2::numeric, true)) as yearalter2,
-    count(nullif(a.histdist = b.histdist, true)) as histdist,
-    count(nullif(a.landmark = b.landmark, true)) as landmark,
-    count(nullif(a.builtfar::double precision = b.builtfar::double precision, true)) as builtfar,
-    count(nullif(a.residfar::double precision = b.residfar::double precision, true)) as residfar,
-    count(nullif(a.commfar::double precision = b.commfar::double precision, true)) as commfar,
-    count(nullif(a.facilfar::double precision = b.facilfar::double precision, true)) as facilfar,
-    count(nullif(a.borocode::numeric = b.borocode::numeric, true)) as borocode,
+    count(*) FILTER (WHERE a.numbldgs::numeric IS DISTINCT FROM b.numbldgs::numeric) 
+    as numbldgs,
+    count(*) FILTER (WHERE a.numfloors::numeric IS DISTINCT FROM b.numfloors::numeric)
+    as numfloors,
+    count(*) FILTER (WHERE a.unitsres::numeric IS DISTINCT FROM b.unitsres::numeric) 
+    as unitsres,
+    count(*) FILTER (WHERE a.unitstotal::numeric IS DISTINCT FROM b.unitstotal::numeric) 
+    as unitstotal,
+    count(*) FILTER (WHERE abs(a.lotfront::numeric - b.lotfront::numeric)>=5 OR 
+        ((a.lotfront IS NULL)::int + (b.lotfront IS NULL)::int) = 1) as lotfront,
+    count(*) FILTER (WHERE abs(a.lotdepth::numeric - b.lotdepth::numeric)>=5 OR 
+        ((a.lotdepth IS NULL)::int + (b.lotdepth IS NULL)::int) = 1) as lotdepth,
+    count(*) FILTER (WHERE abs(a.bldgfront::numeric - b.bldgfront::numeric)>=5 OR 
+        ((a.bldgfront IS NULL)::int + (b.bldgfront IS NULL)::int) = 1) as bldgfront,
+    count(*) FILTER (WHERE abs(a.bldgdepth::numeric - b.bldgdepth::numeric)>=5 OR 
+        ((a.bldgdepth IS NULL)::int + (b.bldgdepth IS NULL)::int) = 1) as bldgdepth,
+    count(*) FILTER (WHERE a.ext IS DISTINCT FROM b.ext) as ext,
+    count(*) FILTER (WHERE a.proxcode IS DISTINCT FROM b.proxcode) as proxcode,
+    count(*) FILTER (WHERE a.irrlotcode IS DISTINCT FROM b.irrlotcode)  as irrlotcode,
+    count(*) FILTER (WHERE a.lottype IS DISTINCT FROM b.lottype) as lottype,
+    count(*) FILTER (WHERE a.bsmtcode IS DISTINCT FROM b.bsmtcode)  as bsmtcode,
+    count(*) FILTER (WHERE abs(a.assessland::numeric - b.assessland::numeric)>=10 OR 
+        ((a.assessland IS NULL)::int + (b.assessland IS NULL)::int) = 1) as assessland,
+    count(*) FILTER (WHERE abs(a.assesstot::numeric - b.assesstot::numeric)>=10 OR 
+        ((a.assesstot IS NULL)::int + (b.assesstot IS NULL)::int) = 1) as assesstot,
+    count(*) FILTER (WHERE abs(a.exempttot::numeric - b.exempttot::numeric)>=10 OR 
+        ((a.exempttot IS NULL)::int + (b.exempttot IS NULL)::int) = 1) as exempttot,
+    count(*) FILTER (WHERE a.yearbuilt::numeric IS DISTINCT FROM b.yearbuilt::numeric)  
+    as yearbuilt,
+    count(*) FILTER (WHERE a.yearalter1::numeric IS DISTINCT FROM b.yearalter1::numeric) 
+    as yearalter1,
+    count(*) FILTER (WHERE a.yearalter2::numeric IS DISTINCT FROM b.yearalter2::numeric) 
+    as yearalter2,
+    count(*) FILTER (WHERE a.histdist IS DISTINCT FROM b.histdist) as histdist,
+    count(*) FILTER (WHERE a.landmark IS DISTINCT FROM b.landmark) as landmark,
+    count(*) FILTER (WHERE a.builtfar::double precision IS DISTINCT FROM 
+    b.builtfar::double precision) as builtfar,
+    count(*) FILTER (WHERE a.residfar::double precision IS DISTINCT FROM 
+    b.residfar::double precision) as residfar,
+    count(*) FILTER (WHERE a.commfar::double precision IS DISTINCT FROM 
+    b.commfar::double precision) as commfar,
+    count(*) FILTER (WHERE a.facilfar::double precision IS DISTINCT FROM 
+    b.facilfar::double precision) as facilfar,
+    count(*) FILTER (WHERE a.borocode::numeric IS DISTINCT FROM  b.borocode::numeric) 
+    as borocode,
     count(nullif(a.bbl::double precision = b.bbl::double precision, true)) as bbl,
-    count(nullif(a.condono::numeric = b.condono::numeric, true)) as condono,
-    count(nullif(a.tract2010 = b.tract2010, true)) as tract2010,
-    count(nullif(abs(a.xcoord::numeric-b.xcoord::numeric) <1, true)) as xcoord,
-    count(nullif(abs(a.ycoord::numeric-b.ycoord::numeric) <1, true)) as ycoord,
-    count(nullif(abs(a.latitude::numeric-b.latitude::numeric) <0.0001, true)) as latitude,
-    count(nullif(abs(a.longitude::numeric-b.longitude::numeric) <0.0001, true)) as longitude,
-    count(nullif(a.zonemap = b.zonemap, true)) as zonemap,
-    count(nullif(a.zmcode = b.zmcode, true)) as zmcode,
-    count(nullif(a.sanborn = b.sanborn, true)) as sanborn,
-    count(nullif(a.taxmap = b.taxmap, true)) as taxmap,
-    count(nullif(a.edesignum = b.edesignum, true)) as edesignum,
-    count(nullif(a.appbbl::double precision = b.appbbl::double precision, true)) as appbbl,
-    count(nullif(a.appdate = b.appdate, true)) as appdate,
-    count(nullif(a.plutomapid = b.plutomapid, true)) as plutomapid,
-    count(nullif(a.sanitdistrict = b.sanitdistrict, true)) as sanitdistrict,
-    count(nullif(a.healthcenterdistrict::numeric = b.healthcenterdistrict::numeric, true)) as healthcenterdistrict,
-    count(nullif(a.firm07_flag = b.firm07_flag, true)) as firm07_flag,
-    count(nullif(a.pfirm15_flag = b.pfirm15_flag, true)) as pfirm15_flag
+    count(*) FILTER (WHERE a.condono::numeric IS DISTINCT FROM b.condono::numeric) as condono,
+    count(*) FILTER (WHERE a.tract2010 IS DISTINCT FROM b.tract2010) as tract2010,
+    count(*) FILTER (WHERE abs(a.xcoord::numeric - b.xcoord::numeric)>=1 OR 
+        ((a.xcoord IS NULL)::int + (b.xcoord IS NULL)::int) = 1) as xcoord,
+    count(*) FILTER (WHERE abs(a.ycoord::numeric - b.ycoord::numeric)>=1 OR 
+        ((a.ycoord IS NULL)::int + (b.ycoord IS NULL)::int) = 1) as ycoord,
+    count(*) FILTER (WHERE abs(a.latitude::numeric - b.latitude::numeric)>=.0001 OR 
+        ((a.latitude IS NULL)::int + (b.latitude IS NULL)::int) = 1) as latitude,
+    count(*) FILTER (WHERE abs(a.longitude::numeric - b.longitude::numeric)>=.0001 OR 
+        ((a.longitude IS NULL)::int + (b.longitude IS NULL)::int) = 1) as longitude,
+    count(*) FILTER (WHERE a.zonemap IS DISTINCT FROM b.zonemap) as zonemap,
+    count(*) FILTER (WHERE a.zmcode IS DISTINCT FROM b.zmcode) as zmcode,
+    count(*) FILTER (WHERE a.sanborn IS DISTINCT FROM b.sanborn) as sanborn,
+    count(*) FILTER (WHERE a.taxmap IS DISTINCT FROM b.taxmap) as taxmap,
+    count(*) FILTER (WHERE a.edesignum IS DISTINCT FROM b.edesignum) as edesignum,
+    count(*) FILTER (WHERE a.appbbl::double precision 
+        IS DISTINCT FROM b.appbbl::double precision) as appbbl,
+    count(*) FILTER (WHERE a.appdate IS DISTINCT FROM b.appdate) as appdate,
+    count(*) FILTER (WHERE a.plutomapid IS DISTINCT FROM b.plutomapid)  as plutomapid,
+    count(*) FILTER (WHERE a.sanitdistrict IS DISTINCT FROM b.sanitdistrict) as sanitdistrict,
+    count(*) FILTER (WHERE a.healthcenterdistrict::numeric 
+        IS DISTINCT FROM b.healthcenterdistrict::numeric) as healthcenterdistrict,
+    count(*) FILTER (WHERE a.firm07_flag IS DISTINCT FROM b.firm07_flag) as firm07_flag,
+    count(*) FILTER (WHERE a.pfirm15_flag IS DISTINCT FROM b.pfirm15_flag)  as pfirm15_flag
     INTO qaqc_mismatch
     FROM export_pluto a
 INNER JOIN dcp_pluto b

--- a/pluto_build/sql/qaqc_mismatch.sql
+++ b/pluto_build/sql/qaqc_mismatch.sql
@@ -3,7 +3,7 @@ WHERE pair = :'VERSION'||' - '||:'VERSION_PREV'
 AND CONDO::boolean = :CONDO
 AND MAPPED::boolean = :MAPPED;
 
-INSERT INTO qaqc_mismatch (
+INSERT INTO dcp_pluto.qaqc_mismatch (
 SELECT
     :'VERSION'||' - '||:'VERSION_PREV' as pair, 
 	:CONDO as condo,

--- a/pluto_build/sql/qaqc_mismatch.sql
+++ b/pluto_build/sql/qaqc_mismatch.sql
@@ -51,7 +51,8 @@ SELECT
     count(*) FILTER (WHERE a.easements::numeric IS DISTINCT FROM b.easements::numeric) as easements,
     count(*) FILTER (WHERE a.ownertype IS DISTINCT FROM b.ownertype) as ownertype,
     count(*) FILTER (WHERE a.ownername IS DISTINCT FROM b.ownername) as ownername,
-    count(nullif(abs(a.lotarea::numeric-b.lotarea::numeric) <5, true)) as lotarea,
+    count(*) FILTER (WHERE abs(a.lotarea::int - b.lotarea::int)>=5 OR 
+        ((a.lotarea IS NULL)::int + (b.lotarea IS NULL)::int) = 1) as lotarea,
     count(nullif(abs(a.bldgarea::numeric-b.bldgarea::numeric) <5, true)) as bldgarea,
     count(nullif(abs(a.comarea::numeric-b.comarea::numeric) <5, true)) as comarea,
     count(nullif(abs(a.resarea::numeric-b.resarea::numeric) <5, true)) as resarea,
@@ -61,7 +62,7 @@ SELECT
     count(nullif(abs(a.strgearea::numeric-b.strgearea::numeric) <5, true)) as strgearea,
     count(nullif(abs(a.factryarea::numeric-b.factryarea::numeric) <5, true)) as factryarea,
     count(nullif(abs(a.otherarea::numeric-b.otherarea::numeric) <5, true)) as otherarea,
-    count(nullif(a.areasource = b.areasource, true)) as areasource,
+    count(*) FILTER (WHERE a.areasource IS DISTINCT FROM b.areasource) as areasource,
     count(nullif(a.numbldgs::numeric = b.numbldgs::numeric, true)) as numbldgs,
     count(nullif(a.numfloors::numeric = b.numfloors::numeric, true)) as numfloors,
     count(nullif(a.unitsres::numeric = b.unitsres::numeric, true)) as unitsres,

--- a/pluto_build/sql/qaqc_mismatch.sql
+++ b/pluto_build/sql/qaqc_mismatch.sql
@@ -1,24 +1,24 @@
--- DELETE FROM qaqc_mismatch 
--- WHERE pair = :'VERSION'||' - '||:'VERSION_PREV' 
--- AND CONDO::boolean = :CONDO
--- AND MAPPED::boolean = :MAPPED;
+DELETE FROM qaqc_mismatch 
+WHERE pair = :'VERSION'||' - '||:'VERSION_PREV' 
+AND CONDO::boolean = :CONDO
+AND MAPPED::boolean = :MAPPED;
 DROP TABLE IF EXISTS qaqc_mismatch;
--- CREATE TABLE qaqc_mismatch (
---     -- pair varchar,
---     -- condo varchar,
---     -- mapped varchar,
---     total numeric,
---     borough numeric,
---     block numeric,
---     lot numeric
---     -- cd numeric 
--- );
+CREATE TABLE qaqc_mismatch (
+    -- pair varchar,
+    -- condo varchar,
+    -- mapped varchar,
+    total numeric,
+    borough numeric,
+    block numeric,
+    lot numeric
+    -- cd numeric 
+);
 
 -- INSERT INTO qaqc_mismatch (
 SELECT
-    -- :'VERSION'||' - '||:'VERSION_PREV' as pair, 
-	-- :CONDO as condo,
-    -- :MAPPED as mapped,
+    :'VERSION'||' - '||:'VERSION_PREV' as pair, 
+	:CONDO as condo,
+    :MAPPED as mapped,
     count(*) as total,
     count(*) FILTER (WHERE a.borough IS DISTINCT FROM b.borough) as borough,
     count(*) FILTER (WHERE a.block::varchar IS DISTINCT FROM b.block::varchar) as block,
@@ -117,7 +117,6 @@ SELECT
     b.facilfar::double precision) as facilfar,
     count(*) FILTER (WHERE a.borocode::numeric IS DISTINCT FROM  b.borocode::numeric) 
     as borocode,
-    count(nullif(a.bbl::double precision = b.bbl::double precision, true)) as bbl,
     count(*) FILTER (WHERE a.condono::numeric IS DISTINCT FROM b.condono::numeric) as condono,
     count(*) FILTER (WHERE a.tract2010 IS DISTINCT FROM b.tract2010) as tract2010,
     count(*) FILTER (WHERE abs(a.xcoord::numeric - b.xcoord::numeric)>=1 OR 
@@ -142,7 +141,7 @@ SELECT
         IS DISTINCT FROM b.healthcenterdistrict::numeric) as healthcenterdistrict,
     count(*) FILTER (WHERE a.firm07_flag IS DISTINCT FROM b.firm07_flag) as firm07_flag,
     count(*) FILTER (WHERE a.pfirm15_flag IS DISTINCT FROM b.pfirm15_flag)  as pfirm15_flag
-    INTO qaqc_mismatch
-    FROM export_pluto a
-INNER JOIN dcp_pluto b
-ON ROUND(a.bbl::float):: bigint = ROUND(b.bbl::float)::bigint;
+    FROM dcp_pluto.:"VERSION" a
+INNER JOIN dcp_pluto.:"VERSION_PREV" b
+ON (a.bbl::bigint = b.bbl::bigint)
+:CONDITION) 


### PR DESCRIPTION
# Fix how mismatch QAQC table treats NULLS
Part of our QAQC process on PLUTO is to produce a count of mismatches for each field for each version pairing. We compare each lot in each build to itself in the previous release. Currently this process fails to count a null and non-null value as a "mismatch." It only counts situations where a lot had a different non-null value in the previous release.

## Existing Implementation
Currently the `qaqc_mismatch.sql` script does try to catch situations where one of the values is null with a `NULLIF` function. This implementation is based on the assumption that if a null and non-null are compared with the `=` operator, a null value is returned. This assumption however wasn't correct.

Other than this one bug, everything in the `qaqc_mismatch.sql` file works well. The only required change is how the equality comparison is done. 

## Implementation for Categorical Fields
Instead of the `=` operator, `IS DISTINCT FROM` is implemented. This [blog post](https://wiki.postgresql.org/wiki/Is_distinct_from) explains why it's what we want. The syntax is also made more readable (`count(*) FILTER (WHERE etc... `) with an approach borrowed from [another blog post](https://stackoverflow.com/questions/29020065/conditional-sql-count)

## Implementation for Continuous Fields
This is slightly more complex as some of these fields have a tolerance for error in what we consider a match. There is no single catch-all built-in function that solves the problem for us and instead two conditionals separated by an `OR` are used. The first conditional checks if the two values are similar enough and the second checks that there isn't exactly one NULL between them.

## Testing this code locally
Currently PLUTO writes the results of `qaqc_mismatch.sql` directly to the qaqc_mismatch table in the PLUTO DB on the publishing database. This is obviously not suitable for developing, and I had to do a fair amount of work to get a local development setup that let me test my new sql code. The improvement to send the QAQC results to DO storage instead of the publishing database is documented in issue #317  