### PR TITLE
delete postgres installation

### DIFF
--- a/.github/workflows/issue-comment-runner.yml
+++ b/.github/workflows/issue-comment-runner.yml
@@ -31,6 +31,7 @@ jobs:
           - 5432:5432
     env:
       BUILD_ENGINE: postgresql://postgres:postgres@localhost:5432/postgres
+      RECIPE_ENGINE: ${{ secrets.RECIPE_ENGINE }}
       EDM_DATA: ${{ secrets.EDM_DATA }}
       AWS_S3_ENDPOINT: ${{ secrets.AWS_S3_ENDPOINT }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/issue-comment-runner.yml
+++ b/.github/workflows/issue-comment-runner.yml
@@ -15,10 +15,22 @@ jobs:
         github.event.comment.user.login == 'AmandaDoyle' ||
         github.event.comment.user.login == 'td928'
       )
-    runs-on: self-hosted
+      
+    runs-on: ubuntu-20.04
+    services:
+      postgres:
+        image: postgis/postgis:12-3.0-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
     env:
-      RECIPE_ENGINE: ${{ secrets.RECIPE_ENGINE }}
-      BUILD_ENGINE: ${{ secrets.BUILD_ENGINE }}
+      BUILD_ENGINE: postgresql://postgres:postgres@localhost:5432/postgres
       EDM_DATA: ${{ secrets.EDM_DATA }}
       AWS_S3_ENDPOINT: ${{ secrets.AWS_S3_ENDPOINT }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/issue-comment-runner.yml
+++ b/.github/workflows/issue-comment-runner.yml
@@ -44,6 +44,7 @@ jobs:
         shell: bash
         run: |
           ./pluto setup init
+          sudo apt install python3-pip
           pip3 install csv2md
 
       - name: dataloading ..

--- a/pluto_build/bin/setup.sh
+++ b/pluto_build/bin/setup.sh
@@ -4,17 +4,8 @@ function setup {
 sudo apt update
 sudo apt install -y curl zip
 
-sudo tee /etc/apt/sources.list.d/pgdg.list << END
-deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main
-END
-# get the signing key and import it
-curl -O https://www.postgresql.org/media/keys/ACCC4CF8.asc
-sudo apt-key add ACCC4CF8.asc
-
-sudo apt update
-sudo apt install -y postgresql-client-11 gdal-bin
-sudo apt autoremove -y
-rm ACCC4CF8.asc
+# install pip for the workflow to run correctly
+sudo apt install python3-pip
 
 curl -O https://dl.min.io/client/mc/release/linux-amd64/mc
 chmod +x mc

--- a/pluto_build/bin/setup.sh
+++ b/pluto_build/bin/setup.sh
@@ -4,9 +4,6 @@ function setup {
 sudo apt update
 sudo apt install -y curl zip
 
-# install pip for the workflow to run correctly
-sudo apt install python3-pip
-
 curl -O https://dl.min.io/client/mc/release/linux-amd64/mc
 chmod +x mc
 sudo mv ./mc /usr/bin

--- a/pluto_build/sql/zoning_specialdistrict.sql
+++ b/pluto_build/sql/zoning_specialdistrict.sql
@@ -3,7 +3,7 @@
 -- the order special purpose districts are assigned is based on which district covers the majority of the lot
 -- a district is only assigned if more than 10% of the district covers the lot
 -- OR more than a specified area of the lot if covered by the district
-DROP TABLE specialpurposeperorder;
+DROP TABLE IF EXISTS specialpurposeperorder;
 CREATE TABLE specialpurposeperorder AS (
 WITH 
 specialpurposeper AS (

--- a/pluto_build/sql/zoning_zonemap.sql
+++ b/pluto_build/sql/zoning_zonemap.sql
@@ -3,7 +3,7 @@
 -- the order zoning maps are assigned is based on which map covers the majority of the lot
 -- a map is only assigned if more than 10% of the map covers the lot
 -- OR more than a specified area of the lot if covered by the map
-DROP TABLE zoningmapperorder;
+DROP TABLE IF EXISTS zoningmapperorder;
 CREATE TABLE zoningmapperorder AS (
 WITH 
 zoningmapper AS (


### PR DESCRIPTION
address issue #325 

# overview
In my attempt to fix the error thrown by prod2, I found the init step was causing an installation issue with postgres. The solution here is to remove the installation step from init. This leads me to find a greater issue with PLUTO github. 

## CI & CI test 
The reason why the issue wasn't spotted earlier was due to at development stage all changes are tested using [test.yml](https://github.com/NYCPlanning/db-pluto/blob/main/.github/workflows/test.yml) and one significant difference between the test and CI is using our self-hosted server vs. running out of github hosted runners with docker postgis image. This is probably we weren't able to catch the CI dependencies issues earlier. 

## Solutions (?)
First one is the one being carried out in this feature branch. Remove the unnecessary installation step to avoid the conflicts and make better documentation of the required setup needs to be done to our build engine (prod2) before pluto production. 

Alternatively, we switched over everything from running on self-hoseted to github hosted streams. Since the most of the test runs [have been successfully executed by the github-hosted runners](https://github.com/NYCPlanning/db-pluto/actions/workflows/test.yml).

 It was noted by @AmandaDoyle that we will lose the intermediate steps in the build with github hosted runner and probably make debugging more challenging. But I found it equally tricky thing trying to set up our build engine (prod2) to perfectly mirror the environment set up by docker which is really the main holdup for pluto build up to this point. 




