### PR TITLE
Add `BCT2020` and `BCTCB2020` fields

### DIFF
--- a/schemas/dcp_mappluto.json
+++ b/schemas/dcp_mappluto.json
@@ -1,8 +1,8 @@
 [
     {
-      "name": "wkt",
-      "type": "STRING",
-      "description": "Feature geometry"
+        "name": "wkt",
+        "type": "STRING",
+        "description": "Feature geometry"
     },
     {
         "name": "borough",
@@ -33,6 +33,16 @@
         "name": "cb2010",
         "type": "STRING",
         "description": "The 2010 US Census Block in which the tax lot is located. Each census block is unique within a census tract (see CT2010)."
+    },
+    {
+        "name": "BCT2020",
+        "type": "STRING",
+        "description": "Combination of borough and 2020 census tract"
+    },
+    {
+        "name": "BCTCB2020",
+        "type": "STRING",
+        "description": "Combination of borough, 2020 census tract, and 2020 census borough"
     },
     {
         "name": "schooldist",
@@ -458,5 +468,4 @@
         "name": "shape_area",
         "type": "FLOAT"
     }
-  ]
-  
+]


### PR DESCRIPTION
The two fields in the mappluto table that weren't present in the schema are `BCT2020`and `BCTCB2020`. These fields are are a concatenation of borough + census tract and borough + census tract + census block respectively. This PR adds the two fields to the schema. Common issue that fields associated with new census geographies aren't updated in each place they should be. 

I think this is a sufficient fix for the publishing action to run, but fields in mappluto are confusing in that 2010 census tracts and blocks can be found in `ct2010` and `cb2010` but the 2020 geographies have to be parsed from the new fields. One potential upgrade is to have consistency here, curious on your thoughts on this @AmandaDoyle 