### PR TITLE
Remove Invalid Leading Punctuation from Owner Names

### DIFF
--- a/pluto_build/03_corrections.sh
+++ b/pluto_build/03_corrections.sh
@@ -7,6 +7,7 @@ echo "Applying corrections to PLUTO"
 psql $BUILD_ENGINE -f sql/corr_lotarea.sql
 psql $BUILD_ENGINE -f sql/corr_yearbuilt_lpc.sql
 psql $BUILD_ENGINE -f sql/corr_ownername_city.sql
+psql $BUILD_ENGINE -f sql/corr_ownername_punctuation.sql
 psql $BUILD_ENGINE -f sql/corr_communitydistrict.sql
 psql $BUILD_ENGINE -f sql/corr_numfloors.sql
 psql $BUILD_ENGINE -f sql/corr_units.sql

--- a/pluto_build/sql/corr_ownername_punctuation.sql
+++ b/pluto_build/sql/corr_ownername_punctuation.sql
@@ -1,3 +1,5 @@
+-- Where the ownername has invalid leading punctuation, remove it and set dcpedited flag to true
+
 UPDATE pluto a
 SET ownername = trim(regexp_replace(a.ownername, '^([.,;><\-_!?`%]+)(.*)', '\2')),
     dcpedited= 't'

--- a/pluto_build/sql/corr_ownername_punctuation.sql
+++ b/pluto_build/sql/corr_ownername_punctuation.sql
@@ -1,0 +1,4 @@
+UPDATE pluto a
+SET ownername = trim(regexp_replace(a.ownername, '^([.,;><\-_!?`%]+)(.*)', '\2')),
+    dcpedited= 't'
+WHERE a.ownername ~ '^([.,;><\-_!?`%]+).*';


### PR DESCRIPTION
Address Issue #340 

There are a number of existing records for ownername with leading punctuation, some of which are valid ("#1", "(Name)"). This PR establishes a blacklist of invalid leading characters and strips them from the beginning of the ownername field. (.,;><\-_!?`%). 
