### PR TITLE
Cleaning Number of Floors: Set to NULL if less than one

### DIFF
--- a/pluto_build/sql/numericfields.sql
+++ b/pluto_build/sql/numericfields.sql
@@ -12,7 +12,7 @@ AND numfloors NOT LIKE '%.%';
 UPDATE pluto a
 SET numfloors = NULL
 WHERE a.numfloors IS NOT NULL 
-AND a.numfloors::DECIMAL < 1;
+AND a.numfloors::numeric < 1;
 -- remove commas from lot area
 UPDATE pluto a
 SET lotarea = REPLACE(lotarea,',','')

--- a/pluto_build/sql/numericfields.sql
+++ b/pluto_build/sql/numericfields.sql
@@ -8,7 +8,11 @@ UPDATE pluto a
 SET numfloors = NULL 
 WHERE a.numfloors ~ '[^0-9]'
 AND numfloors NOT LIKE '%.%';
-
+-- only allow numfloors values >= 1
+UPDATE pluto a
+SET numfloors = NULL
+WHERE a.numfloors IS NOT NULL 
+AND a.numfloors::DECIMAL < 1;
 -- remove commas from lot area
 UPDATE pluto a
 SET lotarea = REPLACE(lotarea,',','')


### PR DESCRIPTION
Addresses #341

Adding to existing logic that sets the # of floors to NULL if there are any non-numeric characters in the field, this PR sets all numfloors values that are less than 1 to NULL.
As of now, there are 42265 records affected. 61 one of those records have some other value besides 0 (0.1, 0.3, etc.)