### PR TITLE
Update NULL X/Y and Long/Lat Fields by calculating lot centroids

### DIFF
--- a/pluto_build/02_build.sh
+++ b/pluto_build/02_build.sh
@@ -99,6 +99,7 @@ psql $BUILD_ENGINE -f sql/spatialjoins.sql
 psql $BUILD_ENGINE -f sql/numericfields_geomfields.sql
 psql $BUILD_ENGINE -f sql/sanitboro.sql
 psql $BUILD_ENGINE -f sql/latlong.sql
+psql $BUILD_ENGINE -f sql/update_empty_coord.sql
 psql $BUILD_ENGINE -c "VACUUM ANALYZE pluto;"
 
 echo 'Populating PLUTO tags and version fields'

--- a/pluto_build/sql/update_empty_coord.sql
+++ b/pluto_build/sql/update_empty_coord.sql
@@ -1,0 +1,24 @@
+-- Replace X/Y and Lat/Long fields that are NULL with Lot Centroids
+-- Update Xcoord, Ycoord, lat, long, and centroid fields
+UPDATE pluto b
+SET xcoord = tmp.new_x,
+	ycoord = tmp.new_y,
+	longitude = tmp.lon,
+	latitude = tmp.lat,
+	centroid = tmp.centroid
+FROM (
+	WITH Centroids AS 
+	(SELECT p.bbl as bbl, 
+	 g.geom_4326 as geom, 
+	 ST_X(ST_Centroid(g.geom_4326)) as lon, 
+	 ST_Y(ST_Centroid(g.geom_4326)) as lat
+	FROM pluto as p, pluto_geom as g
+	WHERE p.xcoord is NULL and p.bbl = g.bbl)
+    SELECT bbl, lon,lat,
+	CAST(ST_X(ST_Transform(ST_SetSRID(ST_MakePoint(lon,lat),4326),2263)) AS INTEGER) as new_x,
+	CAST(ST_Y(ST_Transform(ST_SetSRID(ST_MakePoint(lon,lat),4326),2263)) AS INTEGER) as new_y,
+	ST_SetSRID(ST_MakePoint(lon,lat),4326) as centroid,
+	_ST_CONTAINS(geom, ST_SetSRID(ST_POINT(lon,lat),4326)) as contain
+	FROM Centroids
+) AS tmp
+WHERE b.bbl=tmp.bbl and b.xcoord is NULL and tmp.contain is TRUE

--- a/pluto_build/sql/update_empty_coord.sql
+++ b/pluto_build/sql/update_empty_coord.sql
@@ -1,34 +1,24 @@
 -- Update X/Y and Lat/Long fields that are NULL with values from Lot Centroids
 -- Make sure lot centroids fall within the polygon
-SELECT bbl, centroid, point_surface,
-        _ST_CONTAINS(geom, ST_SetSRID(centroid ,4326)) as contain
-INTO update_table
-FROM(SELECT p.bbl as bbl, p.geom as geom, ST_Centroid(p.geom) as centroid, 
-	 		ST_PointOnSurface(p.geom) as point_surface
+WITH update_table AS
+(
+SELECT bbl, 
+	CASE -- check whether the centroid locates in the polygon, otherwise use the PointOnSurface function
+		WHEN _ST_CONTAINS(geom, ST_SetSRID(centroid ,4326)) IS TRUE THEN centroid
+		ELSE point_surface 
+	END AS centroid 
+FROM(SELECT p.bbl as bbl, p.geom as geom, ST_Centroid(p.geom) AS centroid, 
+	 		ST_PointOnSurface(p.geom) AS point_surface
 	 FROM pluto p
-	 WHERE p.geom IS NOT NULL AND p.xcoord IS NULL) as tmp;
+	 WHERE p.geom IS NOT NULL AND p.xcoord IS NULL) AS tmp
+)
 
--- if the centroid locates in the polygon, then update five fields: x/y, long/lat and centroid  
 UPDATE pluto b
 SET xcoord = ST_X(ST_Transform(t.centroid ,2263)),
 	ycoord = ST_Y(ST_Transform(t.centroid ,2263)),
 	longitude = ST_X(t.centroid),
 	latitude = ST_Y(t.centroid),
 	centroid = ST_SetSRID(t.centroid,4326)
-FROM update_table as t
-WHERE b.xcoord is NULL and b.bbl = t.bbl and t.contain is TRUE
+FROM update_table AS t
+WHERE b.xcoord IS NULL AND b.bbl = t.bbl 
 	AND ST_X(ST_Transform(t.centroid,2263)) IS NOT NULL;
-
--- if the centroid does not locate in the polygon, do not update centroid field
--- use the point on surface instead
-UPDATE pluto b
-SET xcoord = ST_X(ST_Transform(t.point_surface ,2263)),
-	ycoord = ST_Y(ST_Transform(t.point_surface ,2263)),
-	longitude = ST_X(t.point_surface),
-	latitude = ST_Y(t.point_surface),
-	centroid = ST_SetSRID(t.point_surface,4326)
-FROM update_table as t
-WHERE b.xcoord is NULL and b.bbl = t.bbl and t.contain is FALSE
-	and ST_X(ST_Transform(t.point_surface ,2263)) IS NOT NULL;
-
-DROP TABLE IF EXISTS update_table;

--- a/pluto_build/sql/update_empty_coord.sql
+++ b/pluto_build/sql/update_empty_coord.sql
@@ -1,31 +1,34 @@
--- Replace X/Y and Lat/Long fields that are NULL with Lot Centroids
--- Update Xcoord, Ycoord, lat, long, and centroid fields
--- delete the temporary table after using
+-- Update X/Y and Lat/Long fields that are NULL with values from Lot Centroids
+-- Make sure lot centroids fall within the polygon
 SELECT bbl, centroid, point_surface,
         _ST_CONTAINS(geom, ST_SetSRID(centroid ,4326)) as contain
 INTO update_table
 FROM(SELECT p.bbl as bbl, p.geom as geom, ST_Centroid(p.geom) as centroid, 
 	 		ST_PointOnSurface(p.geom) as point_surface
-	 FROM pluto p) as tmp;
+	 FROM pluto p
+	 WHERE p.geom IS NOT NULL AND p.xcoord IS NULL) as tmp;
 
 -- if the centroid locates in the polygon, then update five fields: x/y, long/lat and centroid  
 UPDATE pluto b
-SET xcoord = CAST(ST_X(ST_Transform(t.centroid ,2263)) AS INTEGER),
-	ycoord = CAST(ST_Y(ST_Transform(t.centroid ,2263)) AS INTEGER),
+SET xcoord = ST_X(ST_Transform(t.centroid ,2263)),
+	ycoord = ST_Y(ST_Transform(t.centroid ,2263)),
 	longitude = ST_X(t.centroid),
 	latitude = ST_Y(t.centroid),
 	centroid = ST_SetSRID(t.centroid,4326)
 FROM update_table as t
-WHERE b.xcoord is NULL and b.bbl = t.bbl and t.contain is TRUE;
+WHERE b.xcoord is NULL and b.bbl = t.bbl and t.contain is TRUE
+	AND ST_X(ST_Transform(t.centroid,2263)) IS NOT NULL;
 
 -- if the centroid does not locate in the polygon, do not update centroid field
 -- use the point on surface instead
 UPDATE pluto b
-SET xcoord = CAST(ST_X(ST_Transform(t.point_surface ,2263)) AS INTEGER),
-	ycoord = CAST(ST_Y(ST_Transform(t.point_surface ,2263)) AS INTEGER),
+SET xcoord = ST_X(ST_Transform(t.point_surface ,2263)),
+	ycoord = ST_Y(ST_Transform(t.point_surface ,2263)),
 	longitude = ST_X(t.point_surface),
-	latitude = ST_Y(t.point_surface)
+	latitude = ST_Y(t.point_surface),
+	centroid = ST_SetSRID(t.point_surface,4326)
 FROM update_table as t
-WHERE b.xcoord is NULL and b.bbl = t.bbl and t.contain is FALSE;
+WHERE b.xcoord is NULL and b.bbl = t.bbl and t.contain is FALSE
+	and ST_X(ST_Transform(t.point_surface ,2263)) IS NOT NULL;
 
 DROP TABLE IF EXISTS update_table;


### PR DESCRIPTION
Where both X/Y and Lat/Long fields are NULL, we calculate the lot centroid using unclipped MapPLUTO and check whether the point falls within the boundaries of the lot. If the geometry exists and the point falls in the boundary, we update the X/Y, Lat/Long, and Centroid fields. Originally, there are 13635 rows have NULL values in both X/Y and Lat/Long, after this modification, there are still 2644 rows that has NULL entries regarding geometry. 