### PR TITLE
Refactor bash export script to be dryer

### DIFF
--- a/pluto_build/bin/config.sh
+++ b/pluto_build/bin/config.sh
@@ -66,7 +66,7 @@ function spatial_export {
           $name
       rm -f $name.$ext.zip
       zip -9 $name.$ext.zip *
-      ls | grep -v $name.$ext.zip | xargs rm
+      ls | grep -v $name.$ext.zip | xargs rm -r
   )
 }
 


### PR DESCRIPTION
Because the SHP File Export and FGDB export are basically the same with different command line arguments, the actual export code was abstracted into spatial_export, with wrappers for each datatype to pass in proper arguments