### PR TITLE
Modify the sequence of executing sql files in the build part

### DIFF
--- a/pluto_build/02_build.sh
+++ b/pluto_build/02_build.sh
@@ -89,16 +89,17 @@ psql $BUILD_ENGINE -f sql/landuse.sql
 psql $BUILD_ENGINE -c "VACUUM ANALYZE pluto;"
 
 echo 'Flagging tax lots within the FEMA floodplain'
+psql $BUILD_ENGINE -f sql/latlong.sql
+psql $BUILD_ENGINE -f sql/update_empty_coord.sql
 psql $BUILD_ENGINE -f sql/flood_flag.sql
 psql $BUILD_ENGINE -c "VACUUM ANALYZE pluto;"
 
 echo 'Assigning political values with spatial join'
 # clean up numeric fields
+psql $BUILD_ENGINE -f sql/spatialjoins.sql
 psql $BUILD_ENGINE -f sql/numericfields_geomfields.sql
 psql $BUILD_ENGINE -f sql/sanitboro.sql
 psql $BUILD_ENGINE -f sql/latlong.sql
-psql $BUILD_ENGINE -f sql/update_empty_coord.sql
-psql $BUILD_ENGINE -f sql/spatialjoins.sql
 psql $BUILD_ENGINE -c "VACUUM ANALYZE pluto;"
 
 echo 'Populating PLUTO tags and version fields'

--- a/pluto_build/02_build.sh
+++ b/pluto_build/02_build.sh
@@ -89,17 +89,16 @@ psql $BUILD_ENGINE -f sql/landuse.sql
 psql $BUILD_ENGINE -c "VACUUM ANALYZE pluto;"
 
 echo 'Flagging tax lots within the FEMA floodplain'
-psql $BUILD_ENGINE -f sql/latlong.sql
 psql $BUILD_ENGINE -f sql/flood_flag.sql
 psql $BUILD_ENGINE -c "VACUUM ANALYZE pluto;"
 
 echo 'Assigning political values with spatial join'
-psql $BUILD_ENGINE -f sql/spatialjoins.sql
 # clean up numeric fields
 psql $BUILD_ENGINE -f sql/numericfields_geomfields.sql
 psql $BUILD_ENGINE -f sql/sanitboro.sql
 psql $BUILD_ENGINE -f sql/latlong.sql
 psql $BUILD_ENGINE -f sql/update_empty_coord.sql
+psql $BUILD_ENGINE -f sql/spatialjoins.sql
 psql $BUILD_ENGINE -c "VACUUM ANALYZE pluto;"
 
 echo 'Populating PLUTO tags and version fields'

--- a/pluto_build/02_build.sh
+++ b/pluto_build/02_build.sh
@@ -95,8 +95,8 @@ psql $BUILD_ENGINE -f sql/flood_flag.sql
 psql $BUILD_ENGINE -c "VACUUM ANALYZE pluto;"
 
 echo 'Assigning political values with spatial join'
-# clean up numeric fields
 psql $BUILD_ENGINE -f sql/spatialjoins.sql
+# clean up numeric fields
 psql $BUILD_ENGINE -f sql/numericfields_geomfields.sql
 psql $BUILD_ENGINE -f sql/sanitboro.sql
 psql $BUILD_ENGINE -f sql/latlong.sql

--- a/pluto_build/sql/numericfields_geomfields.sql
+++ b/pluto_build/sql/numericfields_geomfields.sql
@@ -1,3 +1,10 @@
+UPDATE pluto a
+SET xcoord = NULL
+WHERE a.xcoord !~ '[0-9]';
+UPDATE pluto a
+SET ycoord = NULL
+WHERE a.ycoord !~ '[0-9]';
+
 -- add decimal in ct2010 where there is a suffix
 UPDATE pluto a
 SET ct2010 = LEFT(a.ct2010,4)||'.'||RIGHT(a.ct2010,2)

--- a/pluto_build/sql/numericfields_geomfields.sql
+++ b/pluto_build/sql/numericfields_geomfields.sql
@@ -1,10 +1,3 @@
-UPDATE pluto a
-SET xcoord = NULL
-WHERE a.xcoord !~ '[0-9]';
-UPDATE pluto a
-SET ycoord = NULL
-WHERE a.ycoord !~ '[0-9]';
-
 -- add decimal in ct2010 where there is a suffix
 UPDATE pluto a
 SET ct2010 = LEFT(a.ct2010,4)||'.'||RIGHT(a.ct2010,2)


### PR DESCRIPTION
I have modified the sequence of executing the sql files, as we implement the new changes of updating null x/y values and centroids. The spatial join part should be after it. Also, there is an execution of latlong.sql in flagging FEMA floodplain part in the original file, which seems redundant to me, since we are not using the coordinates in any step below that. 