### PR TITLE
Wait for all importing to finish before running .sql files

### DIFF
--- a/pluto_build/01_dataloading.sh
+++ b/pluto_build/01_dataloading.sh
@@ -55,6 +55,7 @@ import_public dcp_colp &
 import_public dof_dtm &
 import_public dof_condo
 
+wait
 
 ## Load local CSV files
 psql $BUILD_ENGINE -f sql/_create.sql


### PR DESCRIPTION
I accidentally took out an important `wait` statement in [this commit](https://github.com/NYCPlanning/db-pluto/commit/962c2e7201e222b65313860a8d3b050e12b97620). I meant to just move the qaqc dataloading to the qaqc bash script but I also moved a `wait` statement that was there previously.
This `wait` statement is important as it tells the script to finish importing all datasets before running the .sql files that process them. I thought that having no `&` operator on the end of the last `import_public` call would do this as the `&` operator tells the script to run commands concurrently and so leaving it off would mean no concurrency. But it turns out you still need the `wait` statement 

The error I identified last night was downstream of this issue, which I why I reported back an issue with the input geocodes
