### PR TITLE
dof condo schema change

### DIFF
--- a/pluto_build/sql/dedupecondotable.sql
+++ b/pluto_build/sql/dedupecondotable.sql
@@ -10,8 +10,8 @@ WHERE id IN (
     SELECT id
     FROM (
         SELECT id,
-        ROW_NUMBER() OVER( PARTITION BY condo_base_bbl,condo_billing_bbl
-        ORDER BY  condo_base_bbl,condo_billing_bbl ) AS row_num
+        ROW_NUMBER() OVER( PARTITION BY condo_base,condo_bill
+        ORDER BY  condo_base,condo_bill ) AS row_num
         FROM pluto_condo ) t
         WHERE t.row_num > 1 );
 
@@ -21,11 +21,11 @@ WHERE id IN (
     SELECT id 
     FROM (
         SELECT id,
-        ROW_NUMBER() OVER(PARTITION BY condo_base_bbl
-        ORDER BY condo_base_bbl) AS row_num
+        ROW_NUMBER() OVER(PARTITION BY condo_base
+        ORDER BY condo_base) AS row_num
         FROM pluto_condo) t
         WHERE t.row_num > 1)
-AND condo_billing_bbl IS NULL;
+AND condo_bill IS NULL;
 
 -- remove duplicate records where base bbl is the same but billing bbl is different
 DELETE FROM pluto_condo
@@ -33,10 +33,10 @@ WHERE id IN (
     SELECT id 
     FROM (
         SELECT id,
-        ROW_NUMBER() OVER(PARTITION BY condo_base_bbl
-        ORDER BY condo_base_bbl) AS row_num
+        ROW_NUMBER() OVER(PARTITION BY condo_base
+        ORDER BY condo_base) AS row_num
         FROM pluto_condo) t
         WHERE t.row_num > 1)
-AND condo_billing_bbl NOT IN (SELECT DISTINCT billingbbl 
+AND condo_bill NOT IN (SELECT DISTINCT billingbbl 
                         FROM pluto_rpad_geo
                         WHERE billingbbl IS NOT NULL);

--- a/pluto_build/sql/dtmmergepolygons.sql
+++ b/pluto_build/sql/dtmmergepolygons.sql
@@ -7,10 +7,10 @@ ALTER TABLE pluto_dtm ADD COLUMN primebbl text;
 -- Set the prime bbl as the billing bbl for condo lots
 -- using the pluto condo table
 UPDATE pluto_dtm
-SET primebbl = condo_billing_bbl
+SET primebbl = condo_bill
 FROM pluto_condo
-WHERE bbl=condo_base_bbl
-AND condo_billing_bbl IS NOT NULL;
+WHERE bbl=condo_base
+AND condo_bill IS NOT NULL;
 
 -- create merged geometries for condo records
 DROP TABLE IF EXISTS pluto_dtm_condosmerged;


### PR DESCRIPTION
To address the schema name changes from dof condo data. For more details of the issue refer to #347. 

The fix is to simply swap out the column names with the new columns name, the [test run on github action](https://github.com/NYCPlanning/db-pluto/runs/7325266830?check_suite_focus=true) does look like the issue was resolved looking at the `build` step the missing column error went away. 
