### PR TITLE
Fix `22v1` QAQC

### DIFF
--- a/pluto_build/06_export.sh
+++ b/pluto_build/06_export.sh
@@ -1,58 +1,58 @@
 #!/bin/bash
 source bin/config.sh
 
-mkdir -p output && 
-  (cd output 
-    echo "version: $VERSION" > version.txt
-    echo "date: $DATE" >> version.txt
-    CSV_export pluto_corrections
-    CSV_export pluto_removed_records
-    zip pluto_corrections.zip *
-    ls | grep -v pluto_corrections.zip | xargs rm
-  )
+# mkdir -p output && 
+#   (cd output 
+#     echo "version: $VERSION" > version.txt
+#     echo "date: $DATE" >> version.txt
+#     CSV_export pluto_corrections
+#     CSV_export pluto_removed_records
+#     zip pluto_corrections.zip *
+#     ls | grep -v pluto_corrections.zip | xargs rm
+#   )
 
-mkdir -p output &&
-  (cd output
-    CSV_export source_data_versions
-  )
+# mkdir -p output &&
+#   (cd output
+#     CSV_export source_data_versions
+#   )
 
-# mappluto.gdb
-FGDB_export mappluto_gdb &
+# # mappluto.gdb
+# FGDB_export mappluto_gdb &
 
-# mappluto_unclipped.gdb
-FGDB_export mappluto_unclipped_gdb &
+# # mappluto_unclipped.gdb
+# FGDB_export mappluto_unclipped_gdb &
 
-# mappluto
-SHP_export mappluto &
+# # mappluto
+# SHP_export mappluto &
 
-# mappluto_unclipped
-SHP_export mappluto_unclipped &
+# # mappluto_unclipped
+# SHP_export mappluto_unclipped &
 
-# Pluto
-mkdir -p output/pluto &&
-  (cd output/pluto
-    rm -f pluto.zip
-    psql $BUILD_ENGINE -c "\COPY ( 
-          SELECT * FROM export_pluto
-        ) TO STDOUT DELIMITER ',' CSV HEADER;" > pluto.csv
-    echo "$VERSION" > version.txt
-    echo "$(wc -l pluto.csv)" >> version.txt
-    zip pluto.zip *
-    ls | grep -v pluto.zip | xargs rm
-  )
+# # Pluto
+# mkdir -p output/pluto &&
+#   (cd output/pluto
+#     rm -f pluto.zip
+#     psql $BUILD_ENGINE -c "\COPY ( 
+#           SELECT * FROM export_pluto
+#         ) TO STDOUT DELIMITER ',' CSV HEADER;" > pluto.csv
+#     echo "$VERSION" > version.txt
+#     echo "$(wc -l pluto.csv)" >> version.txt
+#     zip pluto.zip *
+#     ls | grep -v pluto.zip | xargs rm
+#   )
 
-# BBL and Council info for DOF
-mkdir -p output/dof && 
-  (cd output/dof
-    rm -f bbl_council.zip
-    psql $BUILD_ENGINE -c "\COPY ( 
-          SELECT bbl, council FROM export_pluto
-          WHERE bbl is not null
-        ) TO STDOUT DELIMITER ',' CSV HEADER;" > bbl_council.csv
-    echo "$VERSION" > version.txt
-    zip bbl_council.zip *
-    ls | grep -v bbl_council.zip | xargs rm
-  )
+# # BBL and Council info for DOF
+# mkdir -p output/dof && 
+#   (cd output/dof
+#     rm -f bbl_council.zip
+#     psql $BUILD_ENGINE -c "\COPY ( 
+#           SELECT bbl, council FROM export_pluto
+#           WHERE bbl is not null
+#         ) TO STDOUT DELIMITER ',' CSV HEADER;" > bbl_council.csv
+#     echo "$VERSION" > version.txt
+#     zip bbl_council.zip *
+#     ls | grep -v bbl_council.zip | xargs rm
+#   )
 
 mkdir -p output/qaqc && 
   (cd output/qaqc
@@ -67,7 +67,7 @@ mkdir -p output/qaqc &&
   )
 
 wait
-Upload $VERSION &
+# Upload $VERSION &
 Upload $branchname
 wait
 exit 0

--- a/pluto_build/sql/qaqc_aggregate.sql
+++ b/pluto_build/sql/qaqc_aggregate.sql
@@ -23,5 +23,5 @@ SELECT  :'VERSION' as v,
         sum(ExemptTot::numeric)::bigint as ExemptTot,
         sum(FIRM07_FLAG::numeric)::bigint as FIRM07_FLAG,
         sum(PFIRM15_FLAG::numeric)::bigint as PFIRM15_FLAG
-FROM archive_pluto a
+FROM current_pluto a
 :CONDITION);

--- a/pluto_build/sql/qaqc_expected.sql
+++ b/pluto_build/sql/qaqc_expected.sql
@@ -6,46 +6,46 @@ INSERT INTO qaqc_expected (
 select :'VERSION' as v, jsonb_agg(t) as expected
 from (
 	select jsonb_agg(zonedist1) as values, 'zonedist1' as field
-	from (select distinct zonedist1 from archive_pluto) a
+	from (select distinct zonedist1 from current_pluto) a
 	union
 	select jsonb_agg(zonedist2) as values, 'zonedist2' as field
-	from (select distinct zonedist2 from archive_pluto) a
+	from (select distinct zonedist2 from current_pluto) a
 	union
 	select jsonb_agg(zonedist3) as values, 'zonedist3' as field
-	from (select distinct zonedist3 from archive_pluto) a
+	from (select distinct zonedist3 from current_pluto) a
 	union
 	select jsonb_agg(zonedist4) as values, 'zonedist4' as field
-	from (select distinct zonedist4 from archive_pluto) a
+	from (select distinct zonedist4 from current_pluto) a
 	union
 	select jsonb_agg(overlay1) as values, 'overlay1' as field
-	from (select distinct overlay1 from archive_pluto) a
+	from (select distinct overlay1 from current_pluto) a
 	union
 	select jsonb_agg(overlay2) as values, 'overlay2' as field
-	from (select distinct overlay2 from archive_pluto) a
+	from (select distinct overlay2 from current_pluto) a
 	union
 	select jsonb_agg(spdist1) as values, 'spdist1' as field
-	from (select distinct spdist1 from archive_pluto) a
+	from (select distinct spdist1 from current_pluto) a
 	union
 	select jsonb_agg(spdist2) as values, 'spdist2' as field
-	from (select distinct spdist2 from archive_pluto) a
+	from (select distinct spdist2 from current_pluto) a
 	union
 	select jsonb_agg(spdist3) as values, 'spdist3' as field
-	from (select distinct spdist3 from archive_pluto) a
+	from (select distinct spdist3 from current_pluto) a
 	union
 	select jsonb_agg(ext) as values, 'ext' as field
-	from (select distinct ext from archive_pluto) a
+	from (select distinct ext from current_pluto) a
 	union
 	select jsonb_agg(proxcode) as values, 'proxcode' as field
-	from (select distinct proxcode from archive_pluto) a
+	from (select distinct proxcode from current_pluto) a
 	union
 	select jsonb_agg(irrlotcode) as values, 'irrlotcode' as field
-	from (select distinct irrlotcode from archive_pluto) a
+	from (select distinct irrlotcode from current_pluto) a
 	union
 	select jsonb_agg(lottype) as values, 'lottype' as field
-	from (select distinct lottype from archive_pluto) a
+	from (select distinct lottype from current_pluto) a
 	union
 	select jsonb_agg(bsmtcode) as values, 'bsmtcode' as field
-	from (select distinct bsmtcode from archive_pluto) a
+	from (select distinct bsmtcode from current_pluto) a
 	union 
 	select jsonb_agg(bldgclasslanduse) as values, 'bldgclasslanduse' as field
-	from (select distinct bldgclass||'/'||landuse as bldgclasslanduse  from archive_pluto) a) t);
+	from (select distinct bldgclass||'/'||landuse as bldgclasslanduse  from current_pluto) a) t);

--- a/pluto_build/sql/qaqc_mismatch.sql
+++ b/pluto_build/sql/qaqc_mismatch.sql
@@ -130,7 +130,7 @@ SELECT
         IS DISTINCT FROM b.healthcenterdistrict::numeric) as healthcenterdistrict,
     count(*) FILTER (WHERE a.firm07_flag IS DISTINCT FROM b.firm07_flag) as firm07_flag,
     count(*) FILTER (WHERE a.pfirm15_flag IS DISTINCT FROM b.pfirm15_flag)  as pfirm15_flag
-    FROM archive_pluto a
+    FROM current_pluto a
 INNER JOIN previous_pluto b
 ON (a.bbl::float::bigint = b.bbl::float::bigint)
 :CONDITION)

--- a/pluto_build/sql/qaqc_null.sql
+++ b/pluto_build/sql/qaqc_null.sql
@@ -97,7 +97,7 @@ SELECT
     sum(CASE WHEN a.healthcenterdistrict IS NULL AND b.healthcenterdistrict IS NOT NULL THEN 1 ELSE 0 END) as healthcenterdistrict,
     sum(CASE WHEN a.firm07_flag IS NULL AND b.firm07_flag IS NOT NULL THEN 1 ELSE 0 END) as firm07_flag,
     sum(CASE WHEN a.pfirm15_flag IS NULL AND b.pfirm15_flag IS NOT NULL THEN 1 ELSE 0 END) as pfirm15_flag
-FROM archive_pluto a
+FROM current_pluto a
 INNER JOIN previous_pluto b
 ON (a.bbl::float::bigint = b.bbl::float::bigint)
 :CONDITION);


### PR DESCRIPTION
# Do not merge
I opened this PR to easily share the work I did and have a place for discussion. This is a one-off patch and once this issue is resolved, the PR will be closed without merging

### Existing Issue
The existing issue is that the data under version '22v1' in `qaqc_aggregate`/`qaqc_expected` and pair `22v1 - 21v4` in `qaqc_mismatch`/`qaqc_null' uses a version of 22v1 that is different from the published version of 22v1. The difference is that the 22v1 table used in the QAQC is the most recent build, so it includes more recent source data. 

### Fix going forward
The new QAQC process gets around this process, as there is one set of "correct" QAQC tables associated with each build that live in the main branch that will only be written on publish. 
Additionally, Amanda made a good suggestion of advancing to the next version right after we publish. So all testing builds of PLUTO done between the release of 22v2 and 22v3 will have version = 22v3, and then the latest build of 22v3 will be the release, and then we move on to 22v4. This is a way to ensure this problem is fixed. 

### Fix for 22v1
The work in this repo is to patch this one group of records associated with 22v1. I think the work is pretty straightforward, I pull down two versions from data library and compare them. I checked that the 22v1 table in data library is the same as what is one bytes and it is. 

### Implementing patch
Once this PR is approved, we can manually replace the qaqc files in main/latest with the qaqc files from this branch and then that will be copied down and re-uploaded going forward