### PR TITLE
Add new qaqc_outlier.sql for report generation

### DIFF
--- a/pluto_build/05_qaqc.sh
+++ b/pluto_build/05_qaqc.sh
@@ -10,6 +10,7 @@ import_qaqc qaqc_expected main &
 import_qaqc qaqc_aggregate main &
 import_qaqc qaqc_mismatch main &
 import_qaqc qaqc_null main &
+#import_qaqc qaqc_outlier main &
 
 wait
 

--- a/pluto_build/05_qaqc.sh
+++ b/pluto_build/05_qaqc.sh
@@ -42,7 +42,9 @@ function QAQC {
   -v MAPPED=$mapped  -v CONDITION="$condition" -f $file
 }
 
-
+psql $BUILD_ENGINE \
+  -v VERSION=$VERSION -v VERSION_PREV=$VERSION_PREV \
+  -f sql/qaqc_outlier.sql 
 
 # QAQC MISMATCH ANALYSIS
 for file in sql/qaqc_aggregate.sql sql/qaqc_mismatch.sql sql/qaqc_null.sql

--- a/pluto_build/05_qaqc.sh
+++ b/pluto_build/05_qaqc.sh
@@ -10,7 +10,7 @@ import_qaqc qaqc_expected main &
 import_qaqc qaqc_aggregate main &
 import_qaqc qaqc_mismatch main &
 import_qaqc qaqc_null main &
-#import_qaqc qaqc_outlier main &
+import_qaqc qaqc_outlier main &
 
 wait
 

--- a/pluto_build/05_qaqc.sh
+++ b/pluto_build/05_qaqc.sh
@@ -43,12 +43,8 @@ function QAQC {
   -v MAPPED=$mapped  -v CONDITION="$condition" -f $file
 }
 
-psql $BUILD_ENGINE \
-  -v VERSION=$VERSION -v VERSION_PREV=$VERSION_PREV \
-  -f sql/qaqc_outlier.sql 
-
 # QAQC MISMATCH ANALYSIS
-for file in sql/qaqc_aggregate.sql sql/qaqc_mismatch.sql sql/qaqc_null.sql
+for file in sql/qaqc_aggregate.sql sql/qaqc_mismatch.sql sql/qaqc_null.sql sql/qaqc_outlier.sql
 do
   for mapped in true false
   do

--- a/pluto_build/06_export.sh
+++ b/pluto_build/06_export.sh
@@ -56,7 +56,7 @@ mkdir -p output/dof &&
 
 mkdir -p output/qaqc && 
   (cd output/qaqc
-    for table in qaqc_aggregate qaqc_expected qaqc_mismatch qaqc_null
+    for table in qaqc_aggregate qaqc_expected qaqc_mismatch qaqc_null qaqc_outlier
     do
       psql $BUILD_ENGINE -c "\COPY ( 
           SELECT * FROM ${table}

--- a/pluto_build/sql/qaqc_outlier.sql
+++ b/pluto_build/sql/qaqc_outlier.sql
@@ -2,29 +2,39 @@
 DROP TABLE IF EXISTS qaqc_outlier;
 CREATE TABLE IF NOT EXISTS qaqc_outlier(
     v character varying,
+    CONDO character varying,
+    MAPPED character varying,
     outlier character varying
 );
 
 DELETE FROM qaqc_outlier
-WHERE v = :'VERSION';
+WHERE v = :'VERSION'
+AND CONDO::boolean = :CONDO
+AND MAPPED::boolean = :MAPPED;
 
 INSERT INTO qaqc_outlier (
-select :'VERSION' as v, 	    
-        jsonb_agg(t) as outlier
+select :'VERSION' as v, 	 
+       :CONDO as condo,
+       :MAPPED as mapped,
+       jsonb_agg(t) as outlier
 from (
-	select jsonb_agg(json_build_object('bbl', a.bbl, 'unitsres',a.unitsres, 'resarea', a.resarea,
-                              'res_unit_ratio', a.res_unit_ratio)) as values, 'unitsres_resarea' as field
-	from (SELECT bbl, unitsres, resarea, resarea::FLOAT/unitsres::FLOAT as res_unit_ratio
-          FROM archive_pluto
-          WHERE unitsres::FLOAT>50 and resarea::FLOAT/unitsres::FLOAT < 300
-          AND resarea::FLOAT!= 0) a
+	select jsonb_agg(json_build_object('bbl', tmp.bbl, 'unitsres',tmp.unitsres, 'resarea', tmp.resarea,
+                              'res_unit_ratio', tmp.res_unit_ratio)) as values, 'unitsres_resarea' as field
+	from (SELECT bbl, unitsres, resarea, resarea::INT/unitsres::INT as res_unit_ratio
+          FROM (SELECT a.* 
+                FROM archive_pluto a
+                :CONDITION) b
+          WHERE unitsres::INT>50 and resarea::INT/unitsres::INT < 300
+          AND resarea::INT!= 0)tmp
 	union
-	select jsonb_agg(json_build_object('bbl', a.bbl, 'bldgarea',a.bldgarea, 'lotarea', a.lotarea,
-                              'numfloors', a.numfloors, 'blog_lot_ratio', a.bldg_lot_ratio)) as values, 'lotarea_numfloor' as field
+	select jsonb_agg(json_build_object('bbl', tmp.bbl, 'bldgarea',tmp.bldgarea, 'lotarea', tmp.lotarea,
+                              'numfloors', tmp.numfloors, 'blog_lot_ratio', tmp.bldg_lot_ratio)) as values, 'lotarea_numfloor' as field
 	from (SELECT bbl, bldgarea, lotarea, numfloors, bldgarea::FLOAT/lotarea::FLOAT as bldg_lot_ratio
-          FROM archive_pluto
+          FROM (SELECT a.*
+                FROM archive_pluto a
+                :CONDITION) b
           WHERE bldgarea::FLOAT/lotarea::FLOAT > numfloors::FLOAT*2
-          AND lotarea::FLOAT != 0 AND numfloors !=0) a 
+          AND lotarea::FLOAT != 0 AND numfloors !=0)tmp
     union 
     select jsonb_agg(json_build_object('pair',m.pair, 'bbl', m.bbl,
                                        'building_area_current',m.building_area_current,
@@ -32,7 +42,9 @@ from (
                                        'building_area_increase' as field
     from (SELECT :'VERSION'||' - '||:'VERSION_PREV' as pair, 
                 a.bbl, a.lotarea as building_area_current, b.lotarea as building_area_previous
-          FROM archive_pluto a, previous_pluto b
+          FROM (SELECT a.* 
+                FROM archive_pluto a
+                :CONDITION) a, previous_pluto b
           WHERE a.bbl::FLOAT = b.bbl::FLOAT AND a.lotarea::FLOAT > 2*b.lotarea::FLOAT
-          AND b.lotarea::FLOAT != 0 ) m
+          AND b.lotarea::FLOAT != 0) m
       )t);

--- a/pluto_build/sql/qaqc_outlier.sql
+++ b/pluto_build/sql/qaqc_outlier.sql
@@ -42,7 +42,7 @@ from (
                                        'building_area_increase' as field
     from (SELECT :'VERSION'||' - '||:'VERSION_PREV' as pair,
                 a.bbl, a.lotarea::FLOAT as building_area_current, b.lotarea::FLOAT as building_area_previous, 
-                (a.lotarea::FLOAT-b.lotarea::FLOAT)/b.lotarea::FLOAT as percent_change
+                ((a.lotarea::FLOAT-b.lotarea::FLOAT)/b.lotarea::FLOAT * 100) as percent_change
           FROM (SELECT a.* 
                 FROM archive_pluto a
                 :CONDITION) a, previous_pluto b

--- a/pluto_build/sql/qaqc_outlier.sql
+++ b/pluto_build/sql/qaqc_outlier.sql
@@ -1,5 +1,4 @@
 -- -v VERSION=$VERSION
-DROP TABLE IF EXISTS qaqc_outlier;
 CREATE TABLE IF NOT EXISTS qaqc_outlier(
     v character varying,
     CONDO character varying,

--- a/pluto_build/sql/qaqc_outlier.sql
+++ b/pluto_build/sql/qaqc_outlier.sql
@@ -1,0 +1,38 @@
+-- -v VERSION=$VERSION
+DROP TABLE IF EXISTS qaqc_outlier;
+CREATE TABLE IF NOT EXISTS qaqc_outlier(
+    v character varying,
+    outlier character varying
+);
+
+DELETE FROM qaqc_outlier
+WHERE v = :'VERSION';
+
+INSERT INTO qaqc_outlier (
+select :'VERSION' as v, 	    
+        jsonb_agg(t) as outlier
+from (
+	select jsonb_agg(json_build_object('bbl', a.bbl, 'unitsres',a.unitsres, 'resarea', a.resarea,
+                              'res_unit_ratio', a.res_unit_ratio)) as values, 'unitsres_resarea' as field
+	from (SELECT DISTINCT bbl, unitsres, resarea, resarea::INT/unitsres::INT as res_unit_ratio
+          FROM archive_pluto
+          WHERE unitsres::INT>50 and resarea::INT/unitsres::INT < 300
+          AND resarea::INT != 0) a
+	union
+	select jsonb_agg(json_build_object('bbl', a.bbl, 'bldgarea',a.bldgarea, 'lotarea', a.lotarea,
+                              'numfloors', a.numfloors, 'blog_lot_ratio', a.bldg_lot_ratio)) as values, 'lotarea_numfloor' as field
+	from (SELECT bbl, bldgarea, lotarea, numfloors, bldgarea::FLOAT/lotarea::FLOAT as bldg_lot_ratio
+          FROM archive_pluto
+          WHERE bldgarea::FLOAT/lotarea::FLOAT > numfloors::FLOAT*2
+          AND lotarea::FLOAT != 0) a 
+    union 
+    select jsonb_agg(json_build_object('pair',m.pair, 'bbl', m.bbl,
+                                       'building_area_current',m.building_area_current,
+                                       'building_area_previous',m.building_area_previous)) as values, 
+                                       'building_area_increase' as field
+    from (SELECT :'VERSION'||' - '||:'VERSION_PREV' as pair, 
+                a.bbl, a.lotarea as building_area_current, b.lotarea as building_area_previous
+          FROM archive_pluto a, previous_pluto b
+          WHERE a.bbl::FLOAT = b.bbl::FLOAT AND a.lotarea::FLOAT > 2*b.lotarea::FLOAT
+          AND b.lotarea::FLOAT != 0 ) m
+      )t);

--- a/pluto_build/sql/qaqc_outlier.sql
+++ b/pluto_build/sql/qaqc_outlier.sql
@@ -14,17 +14,17 @@ select :'VERSION' as v,
 from (
 	select jsonb_agg(json_build_object('bbl', a.bbl, 'unitsres',a.unitsres, 'resarea', a.resarea,
                               'res_unit_ratio', a.res_unit_ratio)) as values, 'unitsres_resarea' as field
-	from (SELECT DISTINCT bbl, unitsres, resarea, resarea::INT/unitsres::INT as res_unit_ratio
+	from (SELECT bbl, unitsres, resarea, resarea::FLOAT/unitsres::FLOAT as res_unit_ratio
           FROM archive_pluto
-          WHERE unitsres::INT>50 and resarea::INT/unitsres::INT < 300
-          AND resarea::INT != 0) a
+          WHERE unitsres::FLOAT>50 and resarea::FLOAT/unitsres::FLOAT < 300
+          AND resarea::FLOAT!= 0) a
 	union
 	select jsonb_agg(json_build_object('bbl', a.bbl, 'bldgarea',a.bldgarea, 'lotarea', a.lotarea,
                               'numfloors', a.numfloors, 'blog_lot_ratio', a.bldg_lot_ratio)) as values, 'lotarea_numfloor' as field
 	from (SELECT bbl, bldgarea, lotarea, numfloors, bldgarea::FLOAT/lotarea::FLOAT as bldg_lot_ratio
           FROM archive_pluto
           WHERE bldgarea::FLOAT/lotarea::FLOAT > numfloors::FLOAT*2
-          AND lotarea::FLOAT != 0) a 
+          AND lotarea::FLOAT != 0 AND numfloors !=0) a 
     union 
     select jsonb_agg(json_build_object('pair',m.pair, 'bbl', m.bbl,
                                        'building_area_current',m.building_area_current,

--- a/pluto_build/sql/qaqc_outlier.sql
+++ b/pluto_build/sql/qaqc_outlier.sql
@@ -38,10 +38,12 @@ from (
     union 
     select jsonb_agg(json_build_object('pair',m.pair, 'bbl', m.bbl,
                                        'building_area_current',m.building_area_current,
-                                       'building_area_previous',m.building_area_previous)) as values, 
+                                       'building_area_previous',m.building_area_previous,
+                                       'percent_change',m.percent_change)) as values, 
                                        'building_area_increase' as field
-    from (SELECT :'VERSION'||' - '||:'VERSION_PREV' as pair, 
-                a.bbl, a.lotarea as building_area_current, b.lotarea as building_area_previous
+    from (SELECT :'VERSION'||' - '||:'VERSION_PREV' as pair,
+                a.bbl, a.lotarea::FLOAT as building_area_current, b.lotarea::FLOAT as building_area_previous, 
+                (a.lotarea::FLOAT-b.lotarea::FLOAT)/b.lotarea::FLOAT as percent_change
           FROM (SELECT a.* 
                 FROM archive_pluto a
                 :CONDITION) a, previous_pluto b

--- a/pluto_build/sql/qaqc_outlier.sql
+++ b/pluto_build/sql/qaqc_outlier.sql
@@ -20,12 +20,12 @@ select :'VERSION' as v,
 from (
 	select jsonb_agg(json_build_object('bbl', tmp.bbl, 'unitsres',tmp.unitsres, 'resarea', tmp.resarea,
                               'res_unit_ratio', tmp.res_unit_ratio)) as values, 'unitsres_resarea' as field
-	from (SELECT bbl, unitsres, resarea, resarea::INT/unitsres::INT as res_unit_ratio
+	from (SELECT bbl, unitsres, resarea, resarea::FLOAT/unitsres::FLOAT as res_unit_ratio
           FROM (SELECT a.* 
                 FROM archive_pluto a
                 :CONDITION) b
-          WHERE unitsres::INT>50 and resarea::INT/unitsres::INT < 300
-          AND resarea::INT!= 0)tmp
+          WHERE unitsres::FLOAT>50 and resarea::FLOAT/unitsres::FLOAT < 300
+          AND resarea::FLOAT!= 0)tmp
 	union
 	select jsonb_agg(json_build_object('bbl', tmp.bbl, 'bldgarea',tmp.bldgarea, 'lotarea', tmp.lotarea,
                               'numfloors', tmp.numfloors, 'blog_lot_ratio', tmp.bldg_lot_ratio)) as values, 'lotarea_numfloor' as field


### PR DESCRIPTION
Add one additional qaqc_outlier.sql for outlier report generation. 

There are several questions that I would like to address. 

1. Currently, we are just generating new csv file for the outlier. I am using a similar format as qaqc_expected did, which does not take condo and mapped option into consideration. I am not sure whether this should be the case for the outlier report. It seems like we are just sorting out weird records, and it shouldn't be affected by the condo or mapped option. 