### PR TITLE
Manual Corrections Not Applied and Applied Reports

### DIFF
--- a/pluto_build/06_export.sh
+++ b/pluto_build/06_export.sh
@@ -7,6 +7,8 @@ mkdir -p output &&
     echo "date: $DATE" >> version.txt
     CSV_export pluto_corrections
     CSV_export pluto_removed_records
+    CSV_export pluto_corrections_not_applied
+    CSV_export pluto_corrections_applied
     zip pluto_corrections.zip *
     ls | grep -v pluto_corrections.zip | xargs rm
   )

--- a/pluto_build/sql/corr_communitydistrict.sql
+++ b/pluto_build/sql/corr_communitydistrict.sql
@@ -14,6 +14,20 @@ WHERE a.bbl = b.bbl
 	AND b.field = 'cd'
 	AND a.bbl NOT IN (SELECT bbl FROM pluto_corrections WHERE field = 'cd');
 
+INSERT INTO pluto_corrections_not_applied
+SELECT DISTINCT b.*
+FROM pluto_corrections b, pluto a
+WHERE b.bbl=a.bbl 
+	AND b.field='cd'
+	AND b.old_value <> a.cd;
+
+INSERT INTO pluto_corrections_applied
+SELECT DISTINCT b.*
+FROM pluto_corrections b, pluto a
+WHERE b.bbl=a.bbl 
+	AND b.field='cd' 
+	AND b.old_value = a.cd;
+
 -- Apply correction to PLUTO
 UPDATE pluto a
 SET cd = b.new_value,

--- a/pluto_build/sql/corr_create.sql
+++ b/pluto_build/sql/corr_create.sql
@@ -1,3 +1,25 @@
 -- add field to pluto to indicate a value has been edited
 ALTER TABLE pluto
 ADD COLUMN dcpedited text;
+
+DROP TABLE IF EXISTS pluto_corrections_not_applied;
+CREATE TABLE pluto_corrections_not_applied (
+	bbl 		    VARCHAR,
+	field 	  		VARCHAR,
+	old_value 		VARCHAR,
+	new_value 		VARCHAR,
+	type            VARCHAR,
+    reason          VARCHAR,
+    version         VARCHAR
+);
+
+DROP TABLE IF EXISTS pluto_corrections_applied;
+CREATE TABLE pluto_corrections_applied (
+	bbl 		    VARCHAR,
+	field 	  		VARCHAR,
+	old_value 		VARCHAR,
+	new_value 		VARCHAR,
+	type            VARCHAR,
+    reason          VARCHAR,
+    version         VARCHAR
+);

--- a/pluto_build/sql/corr_lotarea.sql
+++ b/pluto_build/sql/corr_lotarea.sql
@@ -42,6 +42,20 @@ WHERE a.bbl = b.bbl
 	AND b.field = 'lotarea'
 	AND a.bbl NOT IN (SELECT bbl FROM pluto_corrections WHERE field = 'lotarea');
 
+INSERT INTO pluto_corrections_not_applied
+SELECT DISTINCT b.*
+FROM pluto_corrections b, pluto a
+WHERE b.bbl=a.bbl 
+	AND b.field='lotarea' 
+	AND b.old_value::numeric <> a.lotarea::numeric;
+
+INSERT INTO pluto_corrections_applied
+SELECT DISTINCT b.*
+FROM pluto_corrections b, pluto a
+WHERE b.bbl=a.bbl 
+	AND b.field='lotarea' 
+	AND b.old_value::numeric=a.lotarea::numeric;
+
 -- Apply correction to PLUTO
 UPDATE pluto a
 SET lotarea = b.new_value,

--- a/pluto_build/sql/corr_numfloors.sql
+++ b/pluto_build/sql/corr_numfloors.sql
@@ -14,6 +14,21 @@ WHERE a.bbl = b.bbl
 	AND b.field = 'numfloors'
 	AND a.bbl NOT IN (SELECT bbl FROM pluto_corrections WHERE field = 'numfloors');
 
+-- Take note of corrections not applied to pluto
+INSERT INTO pluto_corrections_not_applied
+SELECT DISTINCT b.*
+FROM pluto_corrections b, pluto a
+WHERE b.bbl=a.bbl 
+	AND b.field='numfloors' 
+	AND b.old_value <> a.numfloors;
+
+INSERT INTO pluto_corrections_applied
+SELECT DISTINCT b.*
+FROM pluto_corrections b, pluto a
+WHERE b.bbl=a.bbl 
+	AND b.field='numfloors' 
+	AND b.old_value = a.numfloors;
+
 -- Apply correction to PLUTO
 UPDATE pluto a
 SET numfloors = b.new_value,

--- a/pluto_build/sql/corr_ownername_city.sql
+++ b/pluto_build/sql/corr_ownername_city.sql
@@ -12,6 +12,20 @@ FROM pluto a, pluto_input_research b
 WHERE a.ownername = b.old_value
 	AND a.bbl NOT IN (SELECT bbl FROM pluto_corrections WHERE field = 'ownername');
 
+INSERT INTO pluto_corrections_not_applied
+SELECT DISTINCT b.*
+FROM pluto_corrections b, pluto a
+WHERE b.bbl=a.bbl 
+	AND b.field='ownername' 
+	AND b.old_value <> a.ownername;
+
+INSERT INTO pluto_corrections_applied
+SELECT DISTINCT b.*
+FROM pluto_corrections b, pluto a
+WHERE b.bbl=a.bbl 
+	AND b.field='ownername' 
+	AND b.old_value = a.ownername;
+	
 -- Apply correction to PLUTO
 UPDATE pluto a
 SET ownername = b.new_value,

--- a/pluto_build/sql/corr_units.sql
+++ b/pluto_build/sql/corr_units.sql
@@ -14,6 +14,20 @@ WHERE a.bbl = b.bbl
 	AND b.field = 'unitstotal'
 	AND a.bbl NOT IN (SELECT bbl FROM pluto_corrections WHERE field = 'unitstotal');
 
+INSERT INTO pluto_corrections_not_applied
+SELECT DISTINCT b.*
+FROM pluto_corrections b, pluto a
+WHERE b.bbl=a.bbl 
+	AND b.field='unitstotal' 
+	AND b.old_value <> a.unitstotal;
+
+INSERT INTO pluto_corrections_applied
+SELECT DISTINCT b.*
+FROM pluto_corrections b, pluto a
+WHERE b.bbl=a.bbl 
+	AND b.field='unitstotal' 
+	AND b.old_value = a.unitstotal;
+
 -- Apply correction to PLUTO
 UPDATE pluto a
 SET unitstotal = b.new_value,
@@ -38,6 +52,20 @@ WHERE a.bbl = b.bbl
 	AND a.unitsres=b.old_value
 	AND b.field = 'unitsres'
 	AND a.bbl NOT IN (SELECT bbl FROM pluto_corrections WHERE field = 'unitsres');
+
+INSERT INTO pluto_corrections_not_applied
+SELECT DISTINCT b.*
+FROM pluto_corrections b, pluto a
+WHERE b.bbl=a.bbl 
+	AND b.field='unitsres' 
+	AND b.old_value <> a.unitsres;
+
+INSERT INTO pluto_corrections_applied
+SELECT DISTINCT b.*
+FROM pluto_corrections b, pluto a
+WHERE b.bbl=a.bbl 
+	AND b.field='unitsres' 
+	AND b.old_value = a.unitsres;
 
 -- Apply correction to PLUTO
 UPDATE pluto a

--- a/pluto_build/sql/corr_yearbuilt_lpc.sql
+++ b/pluto_build/sql/corr_yearbuilt_lpc.sql
@@ -14,6 +14,20 @@ WHERE a.bbl = b.bbl
 	AND b.field = 'yearbuilt'
 	AND a.bbl NOT IN (SELECT bbl FROM pluto_corrections WHERE field = 'yearbuilt');
 
+INSERT INTO pluto_corrections_not_applied
+SELECT DISTINCT b.*
+FROM pluto_corrections b, pluto a
+WHERE b.bbl=a.bbl 
+	AND b.field='yearbuilt'
+	AND b.old_value <> a.yearbuilt;
+
+INSERT INTO pluto_corrections_applied
+SELECT DISTINCT b.*
+FROM pluto_corrections b, pluto a
+WHERE b.bbl=a.bbl 
+	AND b.field='yearbuilt' 
+	AND b.old_value = a.yearbuilt;
+
 -- Apply correction to PLUTO
 UPDATE pluto a
 SET yearbuilt = b.new_value,


### PR DESCRIPTION
Addresses #368 

Creates two new tables: pluto_corrections_not_applied and pluto_corrections_applied, both with schemas exactly matching pluto_corrections (bbl, field, old_value, new_value, type, reason, version).

