### PR TITLE
381 Test Github Action - Add Optional Upload/Export Step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Archive
+        shell: bash
+        working-directory: pluto_build
+        run: ./04_archive.sh
+        if: inputs.run_export
+
       - name: install dependencies
         working-directory: pluto_build
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,10 @@ on:
     branches-ignore:
       - main
   workflow_dispatch:
-
+    inputs:
+      run_export:
+        description: 'Run Export Step and Upload to DO'
+        type: boolean
 jobs:
   build:
     runs-on: ubuntu-20.04
@@ -49,3 +52,23 @@ jobs:
         shell: bash
         working-directory: pluto_build
         run: ./03_corrections.sh
+
+      - name: Archive
+        shell: bash
+        working-directory: pluto_build
+        run: ./04_archive.sh
+        if: ${{inputs.run_export}}
+          
+      - name: QAQC
+        shell: bash
+        working-directory: pluto_build
+        run: ./05_qaqc.sh
+        if: ${{inputs.run_export}}
+
+      - name: create shapefile
+        working-directory: pluto_build
+        shell: bash
+        run: |
+          ./06_export.sh
+        if: ${{inputs.run_export}}
+    

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,10 @@ on:
   workflow_dispatch:
     inputs:
       run_export:
-        description: 'Run Export Step and Upload to DO'
+        description: "Run Export Step and Upload to DO"
         type: boolean
+        required: true
+        default: false
 jobs:
   build:
     runs-on: ubuntu-20.04
@@ -42,12 +44,12 @@ jobs:
         working-directory: pluto_build
         shell: bash
         run: ./01_dataloading.sh
-      
+
       - name: building ...
         working-directory: pluto_build
         shell: bash
         run: ./02_build.sh
-      
+
       - name: apply corrections
         shell: bash
         working-directory: pluto_build
@@ -57,18 +59,17 @@ jobs:
         shell: bash
         working-directory: pluto_build
         run: ./04_archive.sh
-        if: ${{inputs.run_export}}
-          
+        if: inputs.run_export
+
       - name: QAQC
         shell: bash
         working-directory: pluto_build
         run: ./05_qaqc.sh
-        if: ${{inputs.run_export}}
+        if: inputs.run_export
 
       - name: create shapefile
         working-directory: pluto_build
         shell: bash
         run: |
           ./06_export.sh
-        if: ${{inputs.run_export}}
-    
+        if: inputs.run_export

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,12 +35,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Archive
-        shell: bash
-        working-directory: pluto_build
-        run: ./04_archive.sh
-        if: inputs.run_export
-
       - name: install dependencies
         working-directory: pluto_build
         shell: bash


### PR DESCRIPTION
In the process of testing the devcontainer work, we were forced to make temporary changes to test.yml to be able to test the github action functioning without merging into main. This seemed like worthwhile functionality to keep, so this PR addresses #381 and adds a new (default false) workflow dispatch input that allows you to create a manual run of the build that also runs the archive/export/upload steps.

Looks like this
<img width="721" alt="Screen Shot 2022-08-01 at 11 14 46 AM" src="https://user-images.githubusercontent.com/3334995/182182093-21e04d94-d9d1-48c9-8c45-c91dbf41ebbe.png">
