### PR TITLE
Rename pipeline for build

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -1,4 +1,4 @@
-name: 🏗️ CI - Test
+name: 🏗️ CI - Run
 
 on:
   push:


### PR DESCRIPTION
Addresses #383 
Renaming pipeline file and title for workflow to reflect new behavior
You can't start a manual run for a "new" pipeline - won't be able to be run that way until its merged