### PR TITLE
Don't automatically drop all tables on dataloading step

### DIFF
--- a/pluto_build/01_dataloading.sh
+++ b/pluto_build/01_dataloading.sh
@@ -2,15 +2,17 @@
 source bin/config.sh
 
 # DROP all tables
-psql $BUILD_ENGINE -c "
-DO \$\$ DECLARE
-    r RECORD;
-BEGIN
-    FOR r IN (SELECT tablename FROM pg_tables WHERE schemaname = 'public' and tablename !='spatial_ref_sys') LOOP
-        EXECUTE 'DROP TABLE IF EXISTS ' || quote_ident(r.tablename) || ' CASCADE';
-    END LOOP;
-END \$\$;
-"
+if [[ $1 == "drop" ]]; then
+    psql $BUILD_ENGINE -c "
+    DO \$\$ DECLARE
+        r RECORD;
+    BEGIN
+        FOR r IN (SELECT tablename FROM pg_tables WHERE schemaname = 'public' and tablename !='spatial_ref_sys') LOOP
+            EXECUTE 'DROP TABLE IF EXISTS ' || quote_ident(r.tablename) || ' CASCADE';
+        END LOOP;
+    END \$\$;
+    "
+fi
 
 # import_public PTS and CAMA from data library
 import_public pluto_pts &


### PR DESCRIPTION
Added an if statement so dataloading will only drop all tables when user includes drop parameter. We don't have to change any of the actions as they all start with an empty database.
Accidentally wiping tables that took an hour to build is a pain, this should get avoid that issue