### PR TITLE
Add dataloading action

### DIFF
--- a/.github/workflows/open_data_dataloading.yml
+++ b/.github/workflows/open_data_dataloading.yml
@@ -1,0 +1,41 @@
+name: Open Data Refresh
+on:
+  workflow_dispatch:
+
+
+jobs:
+  dataload:
+    runs-on: ubuntu-20.04
+    env:
+      AWS_S3_ENDPOINT: ${{ secrets.DO_S3_ENDPOINT }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.DO_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.DO_SECRET_ACCESS_KEY }}
+      AWS_S3_BUCKET: edm-recipes
+    strategy:
+      matrix:
+        dataset:
+          - dcp_cdboundaries_wi
+          - dcp_cb2010_wi
+          - dcp_ct2010_wi
+          - dcp_cb2020_wi
+          - dcp_ct2020_wi
+          - dcp_school_districts
+          - dcp_firecompanies
+          - dcp_councildistricts_wi
+          - dcp_healthareas
+          - dcp_healthcenters
+          - dcp_zoningmapindex
+          - dpr_greenthumb
+          - dsny_frequencies
+          - lpc_historic_districts
+          - lpc_landmarks
+          - dof_dtm
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: NYCPlanning/action-library-archive@v1.1
+        with:
+          name: ${{ matrix.dataset }}
+          s3: true
+          latest: true
+          output_format: pgdump


### PR DESCRIPTION
After working with the publishing action I realized that we could also use library action for dataloading. I looked at the templates of each dataset listed in `01_dataloading.sh` and identified each that pulls from open data, either ww1.nyc.gov or the NYC open data. Then I added an action to run data library upload for each. 

I haven't run it yet, wanted another set of eyes on this to make sure I'm not missing something major. Should speed up our dataloading for PLUTO and then we can add this upgrade to other data products as well