### PR TITLE
Update Workflow's with newer versions of Postgres, Ubuntu, and Checkout action

### DIFF
--- a/.github/workflows/input_cama.yml
+++ b/.github/workflows/input_cama.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   process_cama:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     services:
       postgres:
         image: postgis/postgis:12-3.0-alpine

--- a/.github/workflows/input_cama.yml
+++ b/.github/workflows/input_cama.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     services:
       postgres:
-        image: postgis/postgis:12-3.0-alpine
+        image: postgis/postgis:15-3.3-alpine
         env:
           POSTGRES_PASSWORD: postgres
         options: >-

--- a/.github/workflows/input_cama.yml
+++ b/.github/workflows/input_cama.yml
@@ -30,7 +30,7 @@ jobs:
       GINGER_USER: ${{ secrets.GINGER_USER }}
       GINGER_HOST: ${{ secrets.GINGER_HOST }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: install ssh key
         run: |
           mkdir -p ~/.ssh/

--- a/.github/workflows/input_cama.yml
+++ b/.github/workflows/input_cama.yml
@@ -1,4 +1,4 @@
-name: 📁 CAMA Processing
+name: 📁 CAMA Processing (Input data for PLUTO)
 
 on:
   workflow_dispatch:

--- a/.github/workflows/input_numbldgs.yml
+++ b/.github/workflows/input_numbldgs.yml
@@ -1,4 +1,4 @@
-name: 📁 NumBldgs processing
+name: 📁 Number of Buildings Processing (input data for PLUTO)
 
 on:
   schedule:

--- a/.github/workflows/input_numbldgs.yml
+++ b/.github/workflows/input_numbldgs.yml
@@ -15,7 +15,7 @@ jobs:
       AWS_S3_BUCKET: edm-recipes
       API_TOKEN: ${{ secrets.API_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: install minio ..
         run: |

--- a/.github/workflows/input_numbldgs.yml
+++ b/.github/workflows/input_numbldgs.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   process_numbldgs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       AWS_S3_ENDPOINT: ${{ secrets.DO_S3_ENDPOINT }}
       AWS_ACCESS_KEY_ID: ${{ secrets.DO_ACCESS_KEY_ID }}

--- a/.github/workflows/input_pts.yml
+++ b/.github/workflows/input_pts.yml
@@ -37,7 +37,7 @@ jobs:
       GINGER_USER: ${{ secrets.GINGER_USER }}
       GINGER_HOST: ${{ secrets.GINGER_HOST }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: install ssh key
         run: |
           mkdir -p ~/.ssh/

--- a/.github/workflows/input_pts.yml
+++ b/.github/workflows/input_pts.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   process_pts:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     services:
       postgres:
         image: postgis/postgis:15-3.3-alpine

--- a/.github/workflows/input_pts.yml
+++ b/.github/workflows/input_pts.yml
@@ -25,6 +25,7 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+          --shm-size=2gb
         ports:
           - 5432:5432
     env:

--- a/.github/workflows/input_pts.yml
+++ b/.github/workflows/input_pts.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-22.04
     services:
       postgres:
-        image: postgis/postgis:12-3.0-alpine
+        image: postgis/postgis:15-3.3-alpine
         env:
           POSTGRES_PASSWORD: postgres
         options: >-

--- a/.github/workflows/input_pts.yml
+++ b/.github/workflows/input_pts.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
       - pts/**
-    paths: 
+    paths:
       - pluto_build/python/geocode.py
       - pluto_build/bin/pts.sh
       - pluto_build/sql/_load_pts.sql
@@ -14,7 +14,7 @@ on:
 
 jobs:
   process_pts:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     services:
       postgres:
         image: postgis/postgis:12-3.0-alpine
@@ -54,7 +54,7 @@ jobs:
       - name: process pts
         working-directory: pluto_build
         run: ./pluto import pts
-        
+
       - uses: NYCPlanning/action-library-archive@v1.1
         id: pluto_pts
         with:
@@ -68,7 +68,7 @@ jobs:
       - name: geocode pts
         working-directory: pluto_build
         run: ./pluto geocode pts
-      
+
       - uses: NYCPlanning/action-library-archive@v1.1
         id: pluto_input_geocodes
         with:
@@ -78,7 +78,7 @@ jobs:
           latest: true
           compress: true
           output_format: pgdump csv
-      
+
       - name: clean up pts
         shell: bash
         working-directory: pluto_build

--- a/.github/workflows/input_pts.yml
+++ b/.github/workflows/input_pts.yml
@@ -1,4 +1,4 @@
-name: 📁 PTS processing
+name: 📁 Property Tax System (PTS) processing (input data for PLUTO)
 on:
   push:
     branches:

--- a/.github/workflows/input_pts.yml
+++ b/.github/workflows/input_pts.yml
@@ -14,12 +14,13 @@ on:
 
 jobs:
   process_pts:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     services:
       postgres:
         image: postgis/postgis:15-3.3-alpine
         env:
           POSTGRES_PASSWORD: postgres
+          AWS_EC2_METADATA_DISABLED: "true"
         options: >-
           --health-cmd pg_isready
           --health-interval 10s

--- a/.github/workflows/input_pts.yml
+++ b/.github/workflows/input_pts.yml
@@ -14,13 +14,12 @@ on:
 
 jobs:
   process_pts:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     services:
       postgres:
         image: postgis/postgis:15-3.3-alpine
         env:
           POSTGRES_PASSWORD: postgres
-          AWS_EC2_METADATA_DISABLED: "true"
         options: >-
           --health-cmd pg_isready
           --health-interval 10s

--- a/.github/workflows/issue-comment-runner.yml
+++ b/.github/workflows/issue-comment-runner.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-22.04
     services:
       postgres:
-        image: postgis/postgis:12-3.0-alpine
+        image: postgis/postgis:15-3.3-alpine
         env:
           POSTGRES_PASSWORD: postgres
         options: >-

--- a/.github/workflows/issue-comment-runner.yml
+++ b/.github/workflows/issue-comment-runner.yml
@@ -15,8 +15,8 @@ jobs:
         github.event.comment.user.login == 'AmandaDoyle' ||
         github.event.comment.user.login == 'td928'
       )
-      
-    runs-on: ubuntu-20.04
+
+    runs-on: ubuntu-22.04
     services:
       postgres:
         image: postgis/postgis:12-3.0-alpine
@@ -51,22 +51,22 @@ jobs:
         working-directory: pluto_build
         shell: bash
         run: ./01_dataloading.sh
-      
+
       - name: building ...
         working-directory: pluto_build
         shell: bash
         run: ./02_build.sh
-      
+
       - name: applying corrections ...
         shell: bash
         working-directory: pluto_build
         run: ./03_corrections.sh
-      
+
       - name: archiving ...
         shell: bash
         working-directory: pluto_build
         run: ./04_archive.sh
-          
+
       - name: Creating QAQC tables ...
         shell: bash
         working-directory: pluto_build
@@ -77,7 +77,7 @@ jobs:
         shell: bash
         run: |
           ./06_export.sh
-      
+
       - name: create report
         id: report
         shell: bash
@@ -88,22 +88,22 @@ jobs:
           report="${report//$'\n'/'%0A'}"
           report="${report//$'\r'/'%0D'}"
           echo ::set-output name=report::$report
-              
+
       - name: report results in comment
         if: success()
         uses: peter-evans/create-or-update-comment@v1
         with:
           comment-id: ${{ github.event.comment.id }}
           body: |
-            
+
             ## PLUTO Build Complete! 
-            
+
             <summary> Source Info </summary>
             <details>
-            
+
             ${{ steps.report.outputs.report }}
-            
+
             </details>
-            
+
             for more details, check https://github.com/NYCPlanning/db-pluto/actions/runs/${{ github.run_id }}
           reactions: hooray

--- a/.github/workflows/issue-comment-runner.yml
+++ b/.github/workflows/issue-comment-runner.yml
@@ -37,7 +37,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: install dependencies
         working-directory: pluto_build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Get Version
         id: version
@@ -39,7 +39,7 @@ jobs:
           - dcp_mappluto_clipped
           # - pluto_corrections
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: NYCPlanning/action-library-archive@v1.1
         # if: matrix.dataset != 'pluto_corrections'
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,8 +8,8 @@ on:
 jobs:
   version:
     name: get version
-    runs-on: ubuntu-20.04
-    outputs: 
+    runs-on: ubuntu-22.04
+    outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v2
@@ -20,11 +20,11 @@ jobs:
           source pluto_build/version.env
           echo "::set-output name=version::$VERSION"
           echo "Version is $VERSION"
-  
+
   publish:
     needs: [version]
     name: publishing
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       AWS_S3_ENDPOINT: ${{ secrets.DO_S3_ENDPOINT }}
       AWS_ACCESS_KEY_ID: ${{ secrets.DO_ACCESS_KEY_ID }}
@@ -49,7 +49,7 @@ jobs:
           compress: true
           output_format: pgdump csv shapefile
           version: ${{ needs.version.outputs.version }}
-      
+
       - uses: NYCPlanning/action-library-archive@v1.1
         # if: matrix.dataset == 'pluto_corrections'
         with:
@@ -67,7 +67,7 @@ jobs:
           project_id: ${{ secrets.GCP_PROJECT_ID_DATA_ENGINEERING }}
           service_account_key: ${{ secrets.GCP_GCS_BQ_SA_KEY }}
           export_default_credentials: true
-          
+
       - name: Upload to BigQuery
         if: matrix.dataset == 'dcp_mappluto'
         working-directory: pluto_build

--- a/.github/workflows/publish_historical.yml
+++ b/.github/workflows/publish_historical.yml
@@ -25,7 +25,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.DO_SECRET_ACCESS_KEY }}
       AWS_S3_BUCKET: edm-recipes
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: NYCPlanning/action-library-archive@v1.1
         if: github.event.inputs.library == 'yes'
         with:
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: always() && github.event.inputs.bq == 'yes'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@master
         with:

--- a/.github/workflows/publish_historical.yml
+++ b/.github/workflows/publish_historical.yml
@@ -5,20 +5,20 @@ on:
       version:
         description: version name of the release
         required: false
-        default: '02b'
+        default: "02b"
       library:
         description: run data library load process?
         required: false
-        default: 'yes'
+        default: "yes"
       bq:
         description: run bq load process?
         required: false
-        default: 'yes'
+        default: "yes"
 jobs:
   library:
     name: load to data library
     if: github.event.inputs.library == 'yes'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       AWS_S3_ENDPOINT: ${{ secrets.DO_S3_ENDPOINT }}
       AWS_ACCESS_KEY_ID: ${{ secrets.DO_ACCESS_KEY_ID }}
@@ -38,7 +38,7 @@ jobs:
   bq:
     name: load to bigquery
     needs: library
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: always() && github.event.inputs.bq == 'yes'
     steps:
       - uses: actions/checkout@v2
@@ -48,7 +48,7 @@ jobs:
           project_id: ${{ secrets.GCP_PROJECT_ID_DATA_ENGINEERING }}
           service_account_key: ${{ secrets.GCP_GCS_BQ_SA_KEY }}
           export_default_credentials: true
-          
+
       - name: Upload to BigQuery
         working-directory: pluto_build
         run: ./pluto bq publish_historical dcp_mappluto ${{ github.event.inputs.version }}

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -26,6 +26,7 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+          --shm-size=2gb
         ports:
           - 5432:5432
     env:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -15,7 +15,7 @@ on:
         default: false
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     services:
       postgres:
         image: postgis/postgis:12-3.0-alpine

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-22.04
     services:
       postgres:
-        image: postgis/postgis:12-3.0-alpine
+        image: postgis/postgis:15-3.3-alpine
         env:
           POSTGRES_PASSWORD: postgres
         options: >-

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -35,7 +35,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: install dependencies
         working-directory: pluto_build

--- a/pluto_build/templates/pluto_input_cama_dof.yml
+++ b/pluto_build/templates/pluto_input_cama_dof.yml
@@ -26,6 +26,9 @@ dataset:
 
   info:
     description: |
-      ### CAMA
+      ### CAMA - DOF uses the Computer-Assisted Mass Appraisal System (CAMA) for property
+      tax valuations. Assessors determine parcel market value using one of several valuation
+      methods based on the parcels tax class. Once market value is determined, the assessed
+      value is a percentage calculation of the market value.
     url: null
     dependents: []


### PR DESCRIPTION
Addresses issue #439. 

Minor PR to address maintenance task to update frequently used tools in our github workflows to the "latest and greatest". Pretty simple stuff, the only thing to note is that I added an option to increase the shared memory capacity to `--shm-size=2gb` as the PLUTO build is quite large and the default 64gb of shared memory was not sufficient to build PLUTO. The time to build PLUTO was reduced by about 10 minutes with updated versions of PostgreSQL (performance improvements between versions).

Testing the workflows:

I tested a few of the workflows, and the runs are here:

- Number of Buildings workflow:  https://github.com/NYCPlanning/db-pluto/actions/runs/4758531804
- PLUTO Build workflow: https://github.com/NYCPlanning/db-pluto/actions/runs/4757654516
- PTS processing - unsuccessful run here: https://github.com/NYCPlanning/db-pluto/actions/runs/4765631580. I suspect that it might not be able to be run on a branch other than main. Not sure why else this wouldn't work. Should I just drop the upgrade for this particular test or try merging and running on main?